### PR TITLE
Fix non-leaf tensor backward twice bug

### DIFF
--- a/resnet50/compare_oneflow_and_pytorch_resnet50_speed.py
+++ b/resnet50/compare_oneflow_and_pytorch_resnet50_speed.py
@@ -24,8 +24,8 @@ def main(args):
     res50_module = resnet50()
     # set for eval mode
     # res50_module.eval()
-    image = flow.tensor(image_nd, requires_grad=True)
-    label = flow.tensor(label_nd, dtype=flow.long, requires_grad=False)
+    image = flow.tensor(image_nd)
+    label = flow.tensor(label_nd)
     corss_entropy = flow.nn.CrossEntropyLoss(reduction="mean")
 
     image_gpu = image.to("cuda")
@@ -78,11 +78,11 @@ def main(args):
         torch_res50_module.parameters(), lr=learning_rate, momentum=mom
     )
 
-    image = torch.tensor(image_nd, requires_grad=True)
+    image = torch.tensor(image_nd)
     image_gpu = image.to("cuda")
     corss_entropy = torch.nn.CrossEntropyLoss()
     corss_entropy.to("cuda")
-    label = torch.tensor(label_nd, dtype=torch.long, requires_grad=False).to("cuda")
+    label = torch.tensor(label_nd, dtype=torch.long).to("cuda")
 
     for_time = 0.0
     bp_time = 0.0


### PR DESCRIPTION
由于 `image_gpu` 对象 `requires_grad=True` 且是非叶子结点，第二次backward时会发现它的grad_fn已经执行过，这时会报错。

这是由于我们的to是类似其它op的实现形式，在 `retain_graph=False` 时，一个grad_fn不能执行第二次（Pytorch中其它Op也有类似的机制），但torch中的to和我们实现不大一样，所以torch中不会报错。

目前这个机制还比较合理，后续再考虑to的实现机制，考虑对齐这一点。