### PR TITLE
refine compare_speed_with_pytorch.py output

### DIFF
--- a/scripts/compare_speed_with_pytorch.py
+++ b/scripts/compare_speed_with_pytorch.py
@@ -100,15 +100,15 @@ def test(
             optimizer.step()
         sync(y)
     end = time.time()
-    total_time = end - start
-    time_per_run = total_time / times
+    total_time_ms = (end - start) * 1000
+    time_per_run_ms = total_time_ms / times
     if no_verbose:
-        print(f"{framework_name}: {time_per_run}")
+        print(f"{framework_name}: {time_per_run_ms:.1f}ms")
     else:
         print(
-            f"{framework_name} {module_name} time: {time_per_run} (= {total_time} / {times}, input_shape={input_shape}, backward is {'disabled' if disable_backward else 'enabled'})"
+            f"{framework_name} {module_name} time: {time_per_run_ms:.1f}ms (= {total_time_ms:.1f}ms / {times}, input_shape={input_shape}, backward is {'disabled' if disable_backward else 'enabled'})"
         )
-    return time_per_run
+    return time_per_run_ms
 
 
 if __name__ == "__main__":
@@ -144,9 +144,10 @@ if __name__ == "__main__":
         times=args.times,
         no_verbose=args.no_verbose,
     )
+    relative_speed = pytorch_time / oneflow_time
     if args.no_verbose:
-        print(f"Relative speed: {pytorch_time/oneflow_time}")
+        print(f"Relative speed: {relative_speed:.2f}")
     else:
         print(
-            f"Relative speed: {pytorch_time/oneflow_time} (= {pytorch_time} / {oneflow_time})"
+            f"Relative speed: {relative_speed:.2f} (= {pytorch_time:.1f}ms / {oneflow_time:.1f}ms)"
         )


### PR DESCRIPTION
原格式：
```
PyTorch resnet50 time: 0.045691609382629395 (= 0.9138321876525879 / 20, input_shape=[1, 3, 224, 224], backward is enabled)
OneFlow resnet50 time: 0.04797089099884033 (= 0.9594178199768066 / 20, input_shape=[1, 3, 224, 224], backward is enabled)
Relative speed: 0.9524861521486846 (= 0.045691609382629395 / 0.04797089099884033
```

新格式：

```
PyTorch resnet50 time: 42.4ms (= 847.9ms / 20, input_shape=[1, 3, 224, 224], backward is enabled)
OneFlow resnet50 time: 531.7ms (= 10634.9ms / 20, input_shape=[1, 3, 224, 224], backward is enabled)
Relative speed: 0.08 (= 42.4ms / 531.7ms)

```