### PR TITLE
fix 'times' arg in compare_speed_with_pytorch.py

### DIFF
--- a/scripts/compare_speed_with_pytorch.py
+++ b/scripts/compare_speed_with_pytorch.py
@@ -68,7 +68,6 @@ def test(
         import torch
     Net = getattr(python_module, module_name)
 
-    times = 20
     warmup_times = 5
 
     m = Net()


### PR DESCRIPTION
脚本里有个 bug 是 times 总被 20 覆盖 😂 现在修复了