### PR TITLE
Vision Transformer OneFlow

### DIFF
--- a/ViT/compare.py
+++ b/ViT/compare.py
@@ -1,0 +1,62 @@
+import oneflow as flow
+import torch
+from vit_oneflow.model import VisionTransformer as vit_oneflow
+from vit_oneflow.checkpoint import convert_torch_to_oneflow as flow_load
+from vit_pytorch.model_new import VisionTransformer as vit_torch
+from vit_pytorch.checkpoint_torch import load_checkpoint as torch_load
+import numpy as np
+
+def main():
+
+    checkpoint_path = "/data/rentianhe/code/ViT-OneFlow/models/ViT/weights/checkpoint/imagenet21k+imagenet2012_ViT-B_16.pth"
+
+    # create model
+    flow_model = vit_oneflow(
+             image_size=(384, 384),
+             patch_size=(16, 16),
+             emb_dim=768,
+             mlp_dim=3072,
+             num_heads=12,
+             num_layers=12,
+             num_classes=1000,
+             attn_dropout_rate=0.0,
+             dropout_rate=0.1)
+    
+    torch_model = vit_torch(
+             image_size=(384, 384),
+             patch_size=(16, 16),
+             emb_dim=768,
+             mlp_dim=3072,
+             num_heads=12,
+             num_layers=12,
+             num_classes=1000,
+             attn_dropout_rate=0.0,
+             dropout_rate=0.1)
+    
+    # load checkpoint
+    if checkpoint_path:
+        flow_state_dict = flow_load(checkpoint_path)
+        flow_model.load_state_dict(flow_state_dict, strict=False)
+        print("Load pretrained weights from {}".format(checkpoint_path))
+
+        torch_state_dict = torch_load(checkpoint_path)
+        torch_model.load_state_dict(torch_state_dict, strict=False)
+        print("Load pretrained weights from {}".format(checkpoint_path))
+    
+    test_data = np.ones((1, 3, 384, 384)).astype(np.float32)
+
+    flow_data = flow.tensor(test_data).to("cuda")
+    torch_data = torch.tensor(test_data).to("cuda")
+    # flow_data = flow.tensor(test_data)
+    # torch_data = torch.tensor(test_data)
+    flow_model = flow_model.to("cuda")
+    torch_model = torch_model.to("cuda")
+
+    flow_model.eval()
+    torch_model.eval()
+
+    print(flow_model(flow_data))
+    print(torch_model(torch_data))
+
+if __name__ == '__main__':
+    main()

--- a/ViT/vit_oneflow/checkpoint.py
+++ b/ViT/vit_oneflow/checkpoint.py
@@ -1,0 +1,66 @@
+import torch
+
+checkpoint_path = "/data/rentianhe/code/ViT-OneFlow/models/ViT/weights/checkpoint/imagenet21k+imagenet2012_ViT-B_16.pth"
+
+
+def convert_torch_to_oneflow(path):
+    state_dict = load_checkpoint(path)
+    new_parameters = dict()
+    for key, value in state_dict.items():
+     if "num_batches_tracked" not in key:
+          val = value.detach().cpu().numpy()
+          new_parameters[key] = val
+    return new_parameters
+
+
+def load_checkpoint(path):
+    state_dict = torch.load(path)['state_dict']
+    keys, values = zip(*list(state_dict.items()))
+    state_dict = convert_torch_weight(keys, values)
+    return state_dict
+
+def convert_torch_weight(keys, values):
+    """ Convert jax model parameters with pytorch model parameters """
+    state_dict = {}
+    for key, value in zip(keys, values):
+
+        # convert name to torch names
+        names = key.split('.')
+        torch_names = names
+        # torch_names = replace_names(names)
+        torch_key = key
+
+        # convert values to tensor and check shapes
+        tensor_value = value
+        # check shape
+        num_dim = len(tensor_value.shape)
+
+        if num_dim == 1:
+            tensor_value = tensor_value.squeeze()
+        elif num_dim == 2 and torch_names[-1] == 'weight':
+            # for normal weight, transpose it
+            tensor_value = tensor_value
+        elif num_dim == 3 and torch_names[-1] == 'weight' and torch_names[-2] in ['query', 'key', 'value']:
+            feat_dim, num_heads, head_dim = tensor_value.shape
+            # for multi head attention q/k/v weight
+            dim, head, head_dim = tensor_value.shape
+            tensor_value = tensor_value.view(dim, head * head_dim).t()
+        elif num_dim == 2 and torch_names[-1] == 'bias' and torch_names[-2] in ['query', 'key', 'value']:
+            # for multi head attention q/k/v bias
+            tensor_value = tensor_value.view(-1)
+        elif num_dim == 3 and torch_names[-1] == 'weight' and torch_names[-2] == 'out':
+            # for multi head attention out weight
+            head, head_dim, dim = tensor_value.shape
+            tensor_value = tensor_value.view(head * head_dim, dim).t()
+        elif num_dim == 4 and torch_names[-1] == 'weight':
+            tensor_value = tensor_value
+
+        # print("{}: {}".format(torch_key, tensor_value.shape))
+        state_dict[torch_key] = tensor_value
+    return state_dict
+
+# print(load_checkpoint(checkpoint_path))
+if __name__ == "__main__":
+    state_dict = load_checkpoint(checkpoint_path)
+    for key in state_dict.keys():
+        print(state_dict[key].shape)

--- a/ViT/vit_oneflow/config.py
+++ b/ViT/vit_oneflow/config.py
@@ -1,0 +1,112 @@
+import argparse
+from utils import process_config
+
+
+def get_eval_config():
+    parser = argparse.ArgumentParser("Visual Transformer Evaluation")
+
+    # basic config
+    parser.add_argument("--n-gpu", type=int, default=1, help="number of gpus to use")
+    parser.add_argument("--model-arch", type=str, default="b16", help='model setting to use', choices=['b16', 'b32', 'l16', 'l32', 'h14'])
+    parser.add_argument("--checkpoint-path", type=str, default=None, help="model checkpoint to load weights")
+    parser.add_argument("--image-size", type=int, default=384, help="input image size", choices=[224, 384])
+    parser.add_argument("--batch-size", type=int, default=32, help="batch size")
+    parser.add_argument("--num-workers", type=int, default=8, help="number of workers")
+    parser.add_argument("--data-dir", type=str, default='../data', help='data folder')
+    parser.add_argument("--dataset", type=str, default='ImageNet', help="dataset for fine-tunning/evaluation")
+    parser.add_argument("--num-classes", type=int, default=1000, help="number of classes in dataset")
+    config = parser.parse_args()
+
+    # model config
+    config = eval("get_{}_config".format(config.model_arch))(config)
+
+    print_config(config)
+    return config
+
+
+def get_train_config():
+    parser = argparse.ArgumentParser("Visual Transformer Train/Fine-tune")
+
+    # basic config
+    parser.add_argument("--exp-name", type=str, default="ft", help="experiment name")
+    parser.add_argument("--n-gpu", type=int, default=1, help="number of gpus to use")
+    parser.add_argument("--tensorboard", default=False, action='store_true', help='flag of turnning on tensorboard')
+    parser.add_argument("--model-arch", type=str, default="b16", help='model setting to use', choices=['b16', 'b32', 'l16', 'l32', 'h14'])
+    parser.add_argument("--checkpoint-path", type=str, default=None, help="model checkpoint to load weights")
+    parser.add_argument("--image-size", type=int, default=384, help="input image size", choices=[224, 384])
+    parser.add_argument("--batch-size", type=int, default=32, help="batch size")
+    parser.add_argument("--num-workers", type=int, default=8, help="number of workers")
+    parser.add_argument("--train-steps", type=int, default=10000, help="number of training/fine-tunning steps")
+    parser.add_argument("--lr", type=float, default=1e-3, help="learning rate")
+    parser.add_argument("--wd", type=float, default=1e-4, help='weight decay')
+    parser.add_argument("--warmup-steps", type=int, default=500, help='learning rate warm up steps')
+    parser.add_argument("--data-dir", type=str, default='../data', help='data folder')
+    parser.add_argument("--dataset", type=str, default='ImageNet', help="dataset for fine-tunning/evaluation")
+    parser.add_argument("--num-classes", type=int, default=1000, help="number of classes in dataset")
+    config = parser.parse_args()
+
+    # model config
+    config = eval("get_{}_config".format(config.model_arch))(config)
+    process_config(config)
+    print_config(config)
+    return config
+
+
+def get_b16_config(config):
+    """ ViT-B/16 configuration """
+    config.patch_size = 16
+    config.emb_dim = 768
+    config.mlp_dim = 3072
+    config.num_heads = 12
+    config.num_layers = 12
+    config.attn_dropout_rate = 0.0
+    config.dropout_rate = 0.1
+    return config
+
+
+def get_b32_config(config):
+    """ ViT-B/32 configuration """
+    config = get_b16_config(config)
+    config.patch_size = 32
+    return config
+
+
+def get_l16_config(config):
+    """ ViT-L/16 configuration """
+    config.patch_size = 16
+    config.emb_dim = 1024
+    config.mlp_dim = 4096
+    config.num_heads = 16
+    config.num_layers = 24
+    config.attn_dropout_rate = 0.0
+    config.dropout_rate = 0.1
+    return config
+
+
+def get_l32_config(config):
+    """ Vit-L/32 configuration """
+    config = get_l16_config(config)
+    config.patch_size = 32
+    return config
+
+
+def get_h14_config(config):
+    """  ViT-H/14 configuration """
+    config.patch_size = 14
+    config.emb_dim = 1280
+    config.mlp_dim = 5120
+    config.num_heads = 16
+    config.num_layers = 32
+    config.attn_dropout_rate = 0.0
+    config.dropout_rate = 0.1
+    return config
+
+
+def print_config(config):
+    message = ''
+    message += '----------------- Config ---------------\n'
+    for k, v in sorted(vars(config).items()):
+        comment = ''
+        message += '{:>35}: {:<30}{}\n'.format(str(k), str(v), comment)
+    message += '----------------- End -------------------'
+    print(message)

--- a/ViT/vit_oneflow/eval.py
+++ b/ViT/vit_oneflow/eval.py
@@ -1,0 +1,93 @@
+import os
+import torch
+import oneflow as flow
+import numpy as np
+from tqdm import tqdm
+from model import VisionTransformer
+from config import get_eval_config
+from checkpoint import convert_torch_to_oneflow
+from torch_loader import *
+from ofrecord_data_utils import OFRecordDataLoader
+
+
+def accuracy(output, target, topk=(1,)):
+    """Computes the precision@k for the specified values of k"""""
+    maxk = max(topk)
+    batch_size = target.size(0)
+
+    _, pred = output.topk(maxk, 1, True, True)
+    pred = pred.t()
+    correct = pred.eq(target.view(1, -1).expand_as(pred))
+
+    res = []
+    for k in topk:
+        correct_k = correct[:k].contiguous().view(-1).float().sum(0)
+        res.append(correct_k / batch_size * 100.0)
+    return res
+
+
+def main():
+
+    config = get_eval_config()
+    config.checkpoint_path = "/data/rentianhe/code/ViT-OneFlow/models/ViT/weights/checkpoint/imagenet21k+imagenet2012_ViT-B_16.pth"
+
+    # create model
+    model = VisionTransformer(
+             image_size=(config.image_size, config.image_size),
+             patch_size=(config.patch_size, config.patch_size),
+             emb_dim=config.emb_dim,
+             mlp_dim=config.mlp_dim,
+             num_heads=config.num_heads,
+             num_layers=config.num_layers,
+             num_classes=config.num_classes,
+             attn_dropout_rate=config.attn_dropout_rate,
+             dropout_rate=config.dropout_rate)
+
+    # load checkpoint
+    if config.checkpoint_path:
+        state_dict = convert_torch_to_oneflow(config.checkpoint_path)
+        model.load_state_dict(state_dict)
+        print("Load pretrained weights from {}".format(config.checkpoint_path))
+
+
+    # create dataloader
+    data_loader = eval("{}DataLoader".format(config.dataset))(
+                    # data_dir=os.path.join(config.data_dir, config.dataset),
+                    data_dir = "/data/imagenet/extract",
+                    image_size=config.image_size,
+                    batch_size=config.batch_size,
+                    num_workers=config.num_workers,
+                    split='val')
+    total_batch = len(data_loader)
+
+    # starting evaluation
+    print("Starting evaluation")
+    acc1s = []
+    acc5s = []
+    model.to("cuda")
+    model.eval()
+    with flow.no_grad():
+        pbar = tqdm(enumerate(data_loader), total=total_batch)
+        for batch_idx, (data, target) in pbar:
+            pbar.set_description("Batch {:05d}/{:05d}".format(batch_idx, total_batch))
+            # convert pytorch tensor to flow tensor
+            data = flow.tensor(data.numpy())
+
+            # load oneflow model and process data
+            data = data.to("cuda")
+            pred_logits = model(data)
+
+            # convert to pytorch and evaluation
+            pred_logits = torch.tensor(pred_logits.numpy())
+            acc1, acc5 = accuracy(pred_logits, target, topk=(1, 5))
+
+            acc1s.append(acc1.item())
+            acc5s.append(acc5.item())
+
+            pbar.set_postfix(acc1=acc1.item(), acc5=acc5.item())
+
+    print("Evaluation of model {:s} on dataset {:s}, Acc@1: {:.4f}, Acc@5: {:.4f}".format(config.model_arch, config.dataset, np.mean(acc1s), np.mean(acc5s)))
+
+
+if __name__ == '__main__':
+    main()

--- a/ViT/vit_oneflow/model.py
+++ b/ViT/vit_oneflow/model.py
@@ -1,0 +1,59 @@
+import oneflow as flow
+import oneflow.nn as nn
+import oneflow.F as F
+import numpy as np
+
+class PositionEmbs(nn.Module):
+    def __init__(self, num_patches, emb_dim, dropout_rate=0.1):
+        super(PositionEmbs, self).__init__()
+        self.pos_embedding = nn.Parameter(flow.tensor(np.random.randn(1, num_patches + 1, emb_dim), dtype=flow.float32))
+        if dropout_rate > 0:
+            self.dropout = nn.Dropout(dropout_rate)
+        else:
+            self.dropout = None
+
+    def forward(self, x):
+        out = x + self.pos_embedding
+
+        if self.dropout:
+            out = self.dropout(out)
+
+        return out
+
+class MlpBlock(nn.Module):
+    """ Transformer Feed-Forward Block """
+    def __init__(self, in_dim, mlp_dim, out_dim, dropout_rate=0.1):
+        super(MlpBlock, self).__init__()
+
+        # init layers
+        self.fc1 = nn.Linear(in_dim, mlp_dim)
+        self.fc2 = nn.Linear(mlp_dim, out_dim)
+        self.act = nn.GELU()
+        if dropout_rate > 0.0:
+            self.dropout1 = nn.Dropout(dropout_rate)
+            self.dropout2 = nn.Dropout(dropout_rate)
+        else:
+            self.dropout1 = None
+            self.dropout2 = None
+
+    def forward(self, x):
+
+        out = self.fc1(x)
+        out = self.act(out)
+        if self.dropout1:
+            out = self.dropout1(out)
+
+        out = self.fc2(out)
+        if self.dropout2:
+            out = self.dropout2(out)
+        return out
+
+class LinearGeneral(nn.Module):
+    def __init__(self, in_dim=(768, ), feat_dim=(12, 64)):
+        super(LinearGeneral, self).__init__()
+
+        self.weight = nn.Parameter(flow.tensor(np.random.randn(*in_dim, *feat_dim), dtype=flow.float32))
+        self.bias = nn.Parameter(flow.tensor(np.zeros(*feat_dim), dtype=flow.float32))
+    
+    def forward(self, x, dims):
+        

--- a/ViT/vit_oneflow/ofrecord_data_utils.py
+++ b/ViT/vit_oneflow/ofrecord_data_utils.py
@@ -1,0 +1,86 @@
+import oneflow as flow
+
+import os
+
+
+class OFRecordDataLoader(object):
+    def __init__(
+        self,
+        ofrecord_root: str = "./ofrecord",
+        mode: str = "train",  # "val"
+        dataset_size: int = 9469,
+        batch_size: int = 1,
+    ):
+        channel_last = False
+        output_layout = "NHWC" if channel_last else "NCHW"
+        self.train_record_reader = flow.nn.OfrecordReader(
+            os.path.join(ofrecord_root, mode),
+            batch_size=batch_size,
+            data_part_num=1,
+            part_name_suffix_length=5,
+            random_shuffle=True if mode == "train" else False,
+            shuffle_after_epoch=True if mode == "train" else False,
+        )
+        self.record_label_decoder = flow.nn.OfrecordRawDecoder(
+            "class/label", shape=(), dtype=flow.int32
+        )
+
+        color_space = "RGB"
+        height = 224
+        width = 224
+
+        self.record_image_decoder = (
+            flow.nn.OFRecordImageDecoderRandomCrop("encoded", color_space=color_space)
+            if mode == "train"
+            else flow.nn.OFRecordImageDecoder("encoded", color_space=color_space)
+        )
+
+        self.resize = (
+            flow.nn.image.Resize(target_size=[height, width])
+            if mode == "train"
+            else flow.nn.image.Resize(
+                resize_side="shorter", keep_aspect_ratio=True, target_size=256
+            )
+        )
+
+        self.flip = flow.nn.CoinFlip(batch_size=batch_size) if mode == "train" else None
+
+        rgb_mean = [123.68, 116.779, 103.939]
+        rgb_std = [58.393, 57.12, 57.375]
+        self.crop_mirror_norm = (
+            flow.nn.CropMirrorNormalize(
+                color_space=color_space,
+                output_layout=output_layout,
+                mean=rgb_mean,
+                std=rgb_std,
+                output_dtype=flow.float,
+            )
+            if mode == "train"
+            else flow.nn.CropMirrorNormalize(
+                color_space=color_space,
+                output_layout=output_layout,
+                crop_h=height,
+                crop_w=width,
+                crop_pos_y=0.5,
+                crop_pos_x=0.5,
+                mean=rgb_mean,
+                std=rgb_std,
+                output_dtype=flow.float,
+            )
+        )
+
+        self.batch_size = batch_size
+        self.dataset_size = dataset_size
+
+    def __len__(self):
+        return self.dataset_size // self.batch_size
+
+    def get_batch(self):
+        train_record = self.train_record_reader()
+        label = self.record_label_decoder(train_record)
+        image_raw_buffer = self.record_image_decoder(train_record)
+        image = self.resize(image_raw_buffer)
+        rng = self.flip() if self.flip != None else None
+        image = self.crop_mirror_norm(image[0], rng)
+
+        return image, label

--- a/ViT/vit_oneflow/torch_loader.py
+++ b/ViT/vit_oneflow/torch_loader.py
@@ -1,0 +1,98 @@
+import os
+from torch.utils.data import DataLoader
+from torchvision.datasets import CIFAR10, CIFAR100, ImageFolder
+from torchvision.transforms import transforms
+
+
+__all__ = ['CIFAR10DataLoader', 'ImageNetDataLoader', 'CIFAR100DataLoader']
+
+
+class CIFAR10DataLoader(DataLoader):
+    def __init__(self, data_dir, split='train', image_size=224, batch_size=16, num_workers=8):
+        if split == 'train':
+            train = True
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+        else:
+            train = False
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+
+        self.dataset = CIFAR10(root=data_dir, train=train, transform=transform, download=True)
+
+        super(CIFAR10DataLoader, self).__init__(
+            dataset=self.dataset,
+            batch_size=batch_size,
+            shuffle=False if not train else True,
+            num_workers=num_workers)
+
+
+class CIFAR100DataLoader(DataLoader):
+    def __init__(self, data_dir, split='train', image_size=224, batch_size=16, num_workers=8):
+        if split == 'train':
+            train = True
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+        else:
+            train = False
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+
+        self.dataset = CIFAR100(root=data_dir, train=train, transform=transform, download=True)
+
+        super(CIFAR100DataLoader, self).__init__(
+            dataset=self.dataset,
+            batch_size=batch_size,
+            shuffle=False if not train else True,
+            num_workers=num_workers)
+
+
+class ImageNetDataLoader(DataLoader):
+    def __init__(self, data_dir, split='train', image_size=224, batch_size=16, num_workers=8):
+
+        if split == 'train':
+            transform = transforms.Compose([
+                transforms.Resize((image_size, image_size)),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+        else:
+            transform = transforms.Compose([
+                transforms.Resize((image_size, image_size)),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+
+        self.dataset = ImageFolder(root=os.path.join(data_dir, split), transform=transform)
+        super(ImageNetDataLoader, self).__init__(
+            dataset=self.dataset,
+            batch_size=batch_size,
+            shuffle=True if split == 'train' else False,
+            num_workers=num_workers)
+
+
+if __name__ == '__main__':
+    data_loader = ImageNetDataLoader(
+        data_dir='/data/imagenet/extract',
+        split='val',
+        image_size=384,
+        batch_size=16,
+        num_workers=8)
+
+    for images, targets in data_loader:
+        print(targets)

--- a/ViT/vit_oneflow/utils.py
+++ b/ViT/vit_oneflow/utils.py
@@ -1,0 +1,174 @@
+import os
+import json
+import pandas as pd
+import torch
+from pathlib import Path
+from collections import OrderedDict
+from datetime import datetime
+import importlib
+
+def ensure_dir(dirname):
+    dirname = Path(dirname)
+    if not dirname.is_dir():
+        dirname.mkdir(parents=True, exist_ok=False)
+
+
+def read_json(fname):
+    fname = Path(fname)
+    with fname.open('rt') as handle:
+        return json.load(handle, object_hook=OrderedDict)
+
+
+def write_json(content, fname):
+    fname = Path(fname)
+    with fname.open('wt') as handle:
+        json.dump(content, handle, indent=4, sort_keys=False)
+
+
+def accuracy(output, target, topk=(1,)):
+    """Computes the precision@k for the specified values of k"""""
+    maxk = max(topk)
+    batch_size = target.size(0)
+
+    _, pred = output.topk(maxk, 1, True, True)
+    pred = pred.t()
+    correct = pred.eq(target.view(1, -1).expand_as(pred))
+
+    res = []
+    for k in topk:
+        correct_k = correct[:k].view(-1).float().sum(0)
+        res.append(correct_k / batch_size * 100.0)
+    return res
+
+
+def setup_device(n_gpu_use):
+    n_gpu = torch.cuda.device_count()
+    if n_gpu_use > 0 and n_gpu == 0:
+        print("Warning: There\'s no GPU available on this machine, training will be performed on CPU.")
+        n_gpu_use = 0
+    if n_gpu_use > n_gpu:
+        print("Warning: The number of GPU\'s configured to use is {}, but only {} are available on this machine.".format(n_gpu_use, n_gpu))
+        n_gpu_use = n_gpu
+    device = torch.device('cuda:0' if n_gpu_use > 0 else 'cpu')
+    list_ids = list(range(n_gpu_use))
+    return device, list_ids
+
+def process_config(config):
+    print(' *************************************** ')
+    print(' The experiment name is {} '.format(config.exp_name))
+    print(' *************************************** ')
+
+    # add datetime postfix
+    timestamp = datetime.now().strftime('%y%m%d_%H%M%S')
+    exp_name = config.exp_name + '_{}_bs{}_lr{}_wd{}'.format(config.dataset, config.batch_size, config.lr, config.wd)
+    exp_name += ('_' + timestamp)
+
+    # create some important directories to be used for that experiments
+    config.summary_dir = os.path.join('experiments', 'tb', exp_name)
+    config.checkpoint_dir = os.path.join('experiments', 'save', exp_name, 'checkpoints/')
+    config.result_dir = os.path.join('experiments', 'save', exp_name, 'results/')
+    for dir in [config.summary_dir, config.checkpoint_dir, config.result_dir]:
+        ensure_dir(dir)
+
+    # save config
+    write_json(vars(config), os.path.join('experiments', 'save', exp_name, 'config.json'))
+
+    return config
+
+
+class MetricTracker:
+    def __init__(self, *keys, writer=None):
+        self.writer = writer
+        self._data = pd.DataFrame(index=keys, columns=['total', 'counts', 'average'])
+        self.reset()
+
+    def reset(self):
+        for col in self._data.columns:
+            self._data[col].values[:] = 0
+
+    def update(self, key, value, n=1):
+        if self.writer is not None:
+            self.writer.add_scalar(key, value)
+        self._data.total[key] += value * n
+        self._data.counts[key] += n
+        self._data.average[key] = self._data.total[key] / self._data.counts[key]
+
+    def avg(self, key):
+        return self._data.average[key]
+
+    def result(self):
+        return dict(self._data.average)
+
+
+class TensorboardWriter():
+    def __init__(self, log_dir, enabled):
+        self.writer = None
+        self.selected_module = ""
+
+        if enabled:
+            log_dir = str(log_dir)
+
+            # Retrieve vizualization writer.
+            succeeded = False
+            for module in ["torch.utils.tensorboard", "tensorboardX"]:
+                try:
+                    self.writer = importlib.import_module(module).SummaryWriter(log_dir)
+                    succeeded = True
+                    break
+                except ImportError:
+                    succeeded = False
+                self.selected_module = module
+
+            if not succeeded:
+                message = "Warning: visualization (Tensorboard) is configured to use, but currently not installed on " \
+                    "this machine. Please install TensorboardX with 'pip install tensorboardx', upgrade PyTorch to " \
+                    "version >= 1.1 to use 'torch.utils.tensorboard' or turn off the option in the 'config.json' file."
+                print(message)
+
+        self.step = 0
+        self.mode = ''
+
+        self.tb_writer_ftns = {
+            'add_scalar', 'add_scalars', 'add_image', 'add_images', 'add_audio',
+            'add_text', 'add_histogram', 'add_pr_curve', 'add_embedding'
+        }
+        self.tag_mode_exceptions = {'add_histogram', 'add_embedding'}
+        self.timer = datetime.now()
+
+    def set_step(self, step, mode='train'):
+        self.mode = mode
+        self.step = step
+        if step == 0:
+            self.timer = datetime.now()
+        else:
+            duration = datetime.now() - self.timer
+            self.add_scalar('steps_per_sec', 1 / duration.total_seconds())
+            self.timer = datetime.now()
+
+    def __getattr__(self, name):
+        """
+        If visualization is configured to use:
+            return add_data() methods of tensorboard with additional information (step, tag) added.
+        Otherwise:
+            return a blank function handle that does nothing
+        """
+        if name in self.tb_writer_ftns:
+            add_data = getattr(self.writer, name, None)
+
+            def wrapper(tag, data, *args, **kwargs):
+                if add_data is not None:
+                    # add mode(train/valid) tag
+                    if name not in self.tag_mode_exceptions:
+                        tag = '{}/{}'.format(tag, self.mode)
+                    if name == 'add_embedding':
+                        add_data(tag=tag, mat=data, global_step=self.step, *args, **kwargs)
+                    else:
+                        add_data(tag, data, self.step, *args, **kwargs)
+            return wrapper
+        else:
+            # default action for returning methods defined in this class, set_step() for instance.
+            try:
+                attr = object.__getattr__(name)
+            except AttributeError:
+                raise AttributeError("type object '{}' has no attribute '{}'".format(self.selected_module, name))
+            return attr

--- a/ViT/vit_oneflow_old/configs.py
+++ b/ViT/vit_oneflow_old/configs.py
@@ -1,0 +1,63 @@
+import ml_collections
+
+
+def get_b16_config():
+    """Returns the ViT-B/16 configuration."""
+    config = ml_collections.ConfigDict()
+    config.patches = ml_collections.ConfigDict({'size': (16, 16)})
+    config.hidden_size = 768
+    config.transformer = ml_collections.ConfigDict()
+    config.transformer.mlp_dim = 3072
+    config.transformer.num_heads = 12
+    config.transformer.num_layers = 12
+    config.transformer.attention_dropout_rate = 0.0
+    config.transformer.dropout_rate = 0.1
+    config.classifier = 'token'
+    config.representation_size = None
+    return config
+
+
+def get_b32_config():
+    """Returns the ViT-B/32 configuration."""
+    config = get_b16_config()
+    config.patches.size = (32, 32)
+    return config
+
+
+def get_l16_config():
+    """Returns the ViT-L/16 configuration."""
+    config = ml_collections.ConfigDict()
+    config.patches = ml_collections.ConfigDict({'size': (16, 16)})
+    config.hidden_size = 1024
+    config.transformer = ml_collections.ConfigDict()
+    config.transformer.mlp_dim = 4096
+    config.transformer.num_heads = 16
+    config.transformer.num_layers = 24
+    config.transformer.attention_dropout_rate = 0.0
+    config.transformer.dropout_rate = 0.1
+    config.classifier = 'token'
+    config.representation_size = None
+    return config
+
+
+def get_l32_config():
+    """Returns the ViT-L/32 configuration."""
+    config = get_l16_config()
+    config.patches.size = (32, 32)
+    return config
+
+
+def get_h14_config():
+    """Returns the ViT-L/16 configuration."""
+    config = ml_collections.ConfigDict()
+    config.patches = ml_collections.ConfigDict({'size': (14, 14)})
+    config.hidden_size = 1280
+    config.transformer = ml_collections.ConfigDict()
+    config.transformer.mlp_dim = 5120
+    config.transformer.num_heads = 16
+    config.transformer.num_layers = 32
+    config.transformer.attention_dropout_rate = 0.0
+    config.transformer.dropout_rate = 0.1
+    config.classifier = 'token'
+    config.representation_size = None
+    return config

--- a/ViT/vit_oneflow_old/models.py
+++ b/ViT/vit_oneflow_old/models.py
@@ -16,14 +16,14 @@ class LayerNorm(nn.Module):
     def __init__(self, features, eps=1e-6):
         super(LayerNorm, self).__init__()
         self.eps = eps
-        self.a_2 = nn.Parameter(flow.Tensor(flow.ones(features, dtype=flow.float32)))
-        self.b_2 = nn.Parameter(flow.Tensor(flow.zeros(features, dtype=flow.float32)))
+        self.weight = nn.Parameter(flow.Tensor(flow.ones(features, dtype=flow.float32)))
+        self.bias = nn.Parameter(flow.Tensor(flow.zeros(features, dtype=flow.float32)))
 
     def forward(self, x):
         mean = x.mean(-1, keepdim=True)
 
         std = x.std(dim=-1, keepdim=True)
-        return self.a_2 * (x - mean) / (std + self.eps) + self.b_2
+        return self.weight * (x - mean) / (std + self.eps) + self.bias
 
 # helpers
 def pair(t):

--- a/ViT/vit_oneflow_old/models.py
+++ b/ViT/vit_oneflow_old/models.py
@@ -1,0 +1,210 @@
+import oneflow
+import oneflow.F as F
+import oneflow as flow
+from oneflow import nn
+from oneflow import optim
+import random
+import copy
+
+import numpy as np
+import math
+import configs as configs
+
+class LayerNorm(nn.Module):
+    "Construct a layernorm module (See citation for details)."
+
+    def __init__(self, features, eps=1e-6):
+        super(LayerNorm, self).__init__()
+        self.eps = eps
+        self.a_2 = nn.Parameter(flow.Tensor(flow.ones(features, dtype=flow.float32)))
+        self.b_2 = nn.Parameter(flow.Tensor(flow.zeros(features, dtype=flow.float32)))
+
+    def forward(self, x):
+        mean = x.mean(-1, keepdim=True)
+
+        std = x.std(dim=-1, keepdim=True)
+        return self.a_2 * (x - mean) / (std + self.eps) + self.b_2
+
+# helpers
+def pair(t):
+    return t if isinstance(t, tuple) else (t, t)
+
+class Attention(nn.Module):
+    def __init__(self, config):
+        super(Attention, self).__init__()
+        self.num_attention_heads = config.transformer.num_heads
+        self.attention_head_size = int(config.hidden_size / self.num_attention_heads)
+        self.all_head_size = self.num_attention_heads * self.attention_head_size
+
+        self.query = nn.Linear(config.hidden_size, self.all_head_size)
+        self.key = nn.Linear(config.hidden_size, self.all_head_size)
+        self.value = nn.Linear(config.hidden_size, self.all_head_size)
+
+        self.out = nn.Linear(config.hidden_size, config.hidden_size)
+        self.attn_dropout = nn.Dropout(config.transformer.attention_dropout_rate)
+        self.proj_dropout = nn.Dropout(config.transformer.attention_dropout_rate)
+
+        self.softmax = nn.Softmax(dim=-1)
+    
+    def transpose_for_scores(self, x):
+        # use tuple() instead of directly add flow.Size with tuple
+        x = x.reshape(shape=tuple(x.size()[:-1]) + (self.num_attention_heads, self.attention_head_size))
+        return x.permute(0, 2, 1, 3)
+    
+    def forward(self, x):
+        # to qkv
+        mixed_query = self.query(x)
+        mixed_key = self.key(x)
+        mixed_value = self.value(x)
+        
+        # transpose layer
+        query_layer = self.transpose_for_scores(mixed_query)
+        key_layer = self.transpose_for_scores(mixed_key)
+        value_layer = self.transpose_for_scores(mixed_value)
+
+        # count attention
+        dots = flow.matmul(query_layer, key_layer.transpose(-1, -2))
+        dots = dots / math.sqrt(self.attention_head_size)
+        attentions = self.softmax(dots)
+        attentions = self.attn_dropout(attentions)
+
+        # weight sum
+        context_layer = flow.matmul(attentions, value_layer)
+        context_layer = context_layer.permute(0, 2, 1, 3)
+        new_context_layer_shape = tuple(context_layer.size()[:-2]) + (self.all_head_size, )
+        context_layer = context_layer.view(*new_context_layer_shape)
+
+        # merge and projection
+        attention_output = self.out(context_layer)
+        attention_output = self.proj_dropout(attention_output)
+        return attention_output
+
+class Mlp(nn.Module):
+    def __init__(self, config):
+        super(Mlp, self).__init__()
+        self.fc1 = nn.Linear(config.hidden_size, config.transformer.mlp_dim)
+        self.fc2 = nn.Linear(config.transformer.mlp_dim, config.hidden_size)
+        self.act_fn = nn.GELU()
+        self.dropout = nn.Dropout(config.transformer.dropout_rate)
+
+        self._init_weights()
+    
+    def _init_weights(self):
+        nn.init.xavier_uniform_(self.fc1.weight)
+        nn.init.xavier_uniform_(self.fc2.weight)
+        nn.init.normal_(self.fc1.bias, std=1e-6)
+        nn.init.normal_(self.fc2.bias, std=1e-6)
+    
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act_fn(x)
+        x = self.dropout(x)
+        x = self.fc2(x)
+        x = self.dropout(x)
+        return x
+
+class Embeddings(nn.Module):
+    """Construct the embeddings from patch, position embeddings.
+    """
+    def __init__(self, config, img_size, in_channels=3):
+        super(Embeddings, self).__init__()
+        img_size = pair(img_size)
+        patch_size = pair(config.patches.size)
+        n_patches = (img_size[0] // patch_size[0]) * (img_size[1] // patch_size[1])
+        self.patch_embeddings = nn.Conv2d(
+            in_channels = in_channels,
+            out_channels = config.hidden_size,
+            kernel_size = patch_size,
+            stride = patch_size
+        )
+        self.position_embeddings = nn.Parameter(flow.tensor(np.zeros((1, n_patches+1, config.hidden_size)), dtype=flow.float32))
+        self.cls_token = nn.Parameter(flow.tensor(np.zeros((1, 1, config.hidden_size)), dtype=flow.float32))
+
+        self.dropout = nn.Dropout(config.transformer.dropout_rate)
+    
+    def forward(self, x):
+        B = x.shape[0]
+        cls_tokens = self.cls_token.expand(B, -1, -1)
+
+        # patch embedding
+        x = self.patch_embeddings(x)
+        x = x.flatten(2)
+        x = x.transpose(-1, -2)
+        x = flow.cat((cls_tokens, x), dim=1)
+
+        # add position embeddings
+        embeddings = x + self.position_embeddings
+        embeddings = self.dropout(embeddings)
+        return embeddings
+
+class Block(nn.Module):
+    def __init__(self, config):
+        super(Block, self).__init__()
+        self.hidden_size = config.hidden_size
+        self.attention_norm = LayerNorm(config.hidden_size, eps=1e-6)
+        self.ffn_norm = LayerNorm(config.hidden_size, eps=1e-6)
+        self.ffn = Mlp(config)
+        self.attn = Attention(config)
+
+    def forward(self, x):
+        # self-attention with pre-norm
+        h = x
+        x = self.attention_norm(x)
+        x = self.attn(x)
+        x = x + h
+        # ffn with pre-norm
+        h = x
+        x = self.ffn_norm(x)
+        x = self.ffn(x)
+        x = x + h
+        return x
+
+class Encoder(nn.Module):
+    def __init__(self, config):
+        super(Encoder, self).__init__()
+        self.layer = nn.ModuleList()
+        self.encoder_norm = LayerNorm(config.hidden_size, eps=1e-6)
+        for _ in range(config.transformer.num_layers):
+            layer = Block(config)
+            self.layer.append(layer)
+
+    def forward(self, hidden_states):
+        for layer_block in self.layer:
+            hidden_states = layer_block(hidden_states)
+        encoded = self.encoder_norm(hidden_states)
+        return encoded
+
+class Transformer(nn.Module):
+    def __init__(self, config, img_size):
+        super(Transformer, self).__init__()
+        self.embeddings = Embeddings(config, img_size=img_size)
+        self.encoder = Encoder(config)
+
+    def forward(self, input_ids):
+        embedding_output = self.embeddings(input_ids)
+        encoded = self.encoder(embedding_output)
+        return encoded
+
+class VisionTransformer(nn.Module):
+    def __init__(self, config, img_size=224, num_classes=100, zero_head=False, vis=False):
+        super(VisionTransformer, self).__init__()
+        self.num_classes = num_classes
+        self.zero_head = zero_head
+        self.classifier = config.classifier
+
+        self.transformer = Transformer(config, img_size)
+        self.head = nn.Linear(config.hidden_size, num_classes)
+
+    def forward(self, x):
+        x = self.transformer(x)
+        logits = self.head(x[:, 0])
+        return logits
+
+
+CONFIGS = {
+    'ViT-B_16': configs.get_b16_config(),
+    'ViT-B_32': configs.get_b32_config(),
+    'ViT-L_16': configs.get_l16_config(),
+    'ViT-L_32': configs.get_l32_config(),
+    'ViT-H_14': configs.get_h14_config(),
+}

--- a/ViT/vit_oneflow_old/train.py
+++ b/ViT/vit_oneflow_old/train.py
@@ -1,0 +1,291 @@
+import argparse
+import numpy as np
+import os
+import time
+import logging
+
+from utils.ofrecord_data_utils import OFRecordDataLoader
+from utils.lr_scheduler import WarmupCosineSchedule, WarmupLinearSchedule
+from tqdm import tqdm
+from models import CONFIGS, VisionTransformer
+
+
+import oneflow
+import oneflow.F as F
+import oneflow as flow
+from oneflow import nn
+from oneflow import optim
+import random
+
+logger = logging.getLogger(__name__)
+
+class AverageMeter(object):
+    """Computes and stores the average and current value"""
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self.val = 0
+        self.avg = 0
+        self.sum = 0
+        self.count = 0
+
+    def update(self, val, n=1):
+        self.val = val
+        self.sum += val * n
+        self.count += n
+        self.avg = self.sum / self.count
+
+def simple_accuracy(preds, labels):
+    return (preds == labels).mean()
+
+def build_loader(args):
+    train_data_loader = OFRecordDataLoader(
+        ofrecord_root=args.data_path,
+        mode="train",
+        dataset_size=args.num_train_examples,
+        batch_size=args.train_batch_size,
+    )
+
+    val_data_loader = OFRecordDataLoader(
+        ofrecord_root=args.data_path,
+        mode="validation",
+        dataset_size=args.num_val_examples,
+        batch_size=args.eval_batch_size,
+    )
+    return train_data_loader, val_data_loader
+
+
+def setup(args):
+    # Prepare model
+    config = CONFIGS[args.model_type]
+    if args.dataset == "imagenet":
+        num_classes = 1000
+
+    model = VisionTransformer(config, args.img_size, zero_head=True, num_classes=num_classes)
+    if args.pretrained_dir:
+        model.load_state_dict(flow.load(args.pretrained_dir), strict=False)
+    model.to("cuda")
+
+
+    logger.info("{}".format(config))
+    return args, model
+
+# def clip_gradient(optimizer, grad_clip):
+#     """
+#     Clips gradients computed during backpropagation to avoid explosion of gradients.
+
+#     :param optimizer: optimizer with the gradients to be clipped
+#     :param grad_clip: clip value
+#     """
+#     for group in optimizer.param_groups:
+#         for param in group["params"]:
+#             if param.grad is not None:
+#                 param.grad.data.clamp_(-grad_clip, grad_clip)
+
+def train(args, model):
+    # add gradient steps
+    args.train_batch_size = args.train_batch_size // args.gradient_accumulation_steps
+    
+    # Prepare dataset
+    train_data_loader, test_data_loader = build_loader(args)
+
+    # Prepare optimizer and scheduler
+    optimizer = optim.SGD(model.parameters(),
+                          lr = args.learning_rate,
+                          momentum = 0.9)
+    
+    # define criterion
+    criterion = flow.nn.CrossEntropyLoss().to("cuda")
+
+    # total fine-tune steps
+    t_total = args.num_steps
+    if args.decay_type == "cosine":
+        scheduler = WarmupCosineSchedule(optimizer, warmup_steps=args.warmup_steps, t_total=t_total)
+    else:
+        scheduler = WarmupLinearSchedule(optimizer, warmup_steps=args.warmup_steps, t_total=t_total)
+
+    # Train
+    # logger.info("***** Running training *****")
+    # logger.info("  Total optimization steps = %d", args.num_steps)
+    # logger.info("  Instantaneous batch size per GPU = %d", args.train_batch_size)
+    # logger.info("  Total train batch size (w. parallel & accumulation) = %d",
+    #             args.train_batch_size * args.gradient_accumulation_steps)
+    # logger.info("  Gradient Accumulation steps = %d", args.gradient_accumulation_steps)
+
+
+    print("***** Runing Training *****")
+    print("  Total optimization steps = %d" % args.num_steps)
+    print("  Instantaneous batch size per GPU = %d" % args.train_batch_size)
+    print("  Total train batch size (w. parallel & accumulation) = %d" %
+                (args.train_batch_size * args.gradient_accumulation_steps))
+    print("  Gradient Accumulation steps = %d" % args.gradient_accumulation_steps)
+
+    # model.zero_grad()
+    losses = AverageMeter()
+    batch_time = AverageMeter()
+    global_step, best_acc = 0, 0
+    while True:
+        model.train()
+        for step in range(len(train_data_loader)):
+            image, label = train_data_loader.get_batch()
+
+            # oneflow train
+            image = image.to("cuda")
+            label = label.to("cuda")
+            logits = model(image)
+            loss = criterion(logits, label)
+            
+            if args.gradient_accumulation_steps > 1:
+                loss = loss / args.gradient_accumulation_steps
+            
+            loss.backward()
+
+            if (step + 1) % args.gradient_accumulation_steps == 0:
+                losses.update(loss.numpy() * args.gradient_accumulation_steps)
+                # clip_gradient(optimizer, 1.0)
+                scheduler.step()
+
+                optimizer.step()
+                optimizer.zero_grad()
+                global_step += 1
+                
+                # current learning rate
+                learning_rate = optimizer.param_groups[0]['lr']
+
+                print(
+                    "Training (%d / %d Steps) (loss=%2.5f) (learning_rate=%2.5f)" % (global_step, t_total, losses.val, learning_rate)
+                )
+
+                if global_step % args.eval_every == 0:
+                    accuracy = valid(args, model, test_data_loader, global_step)
+                    if best_acc < accuracy:
+                        best_acc = accuracy
+                    model.train()
+                
+                if global_step % t_total == 0:
+                    break
+    
+        losses.reset()
+        if global_step % t_total == 0:
+            break
+    
+
+    print("Best Accuracy: \t%f" % best_acc)
+    print("End Training!")
+
+
+def valid(args, model, test_data_loader, global_step):
+    # Validation
+    eval_losses = AverageMeter()
+    print("***** Run Validation *****")
+    print(" Num Steps = %d" % len(test_data_loader))
+    print("  Batch size = %d" % args.eval_batch_size)
+    
+    model.eval()
+    all_preds, all_label = [], []
+
+    loss_func = nn.CrossEntropyLoss().to("cuda")
+    for steps in tqdm(range(len(test_data_loader))):
+        image, label = test_data_loader.get_batch()
+        image = image.to("cuda")
+        label = label.to("cuda")
+        with flow.no_grad():
+            logits = model(image)
+            eval_loss = loss_func(logits, label)
+            eval_losses.update(eval_loss.numpy())
+
+        # turn tensor to numpy.ndarray
+        preds = logits.numpy()
+        preds = np.argmax(preds, axis=-1)
+        label_numpy = label.numpy()
+
+        # collect results
+        if len(all_preds) == 0:
+            all_preds.append(preds)
+            all_label.append(label_numpy)
+        else:
+            all_preds[0] = np.append(
+                all_preds[0], preds, axis=0
+            )
+            all_label[0] = np.append(
+                all_label[0], label_numpy, axis=0
+            )
+
+    
+    all_preds, all_label = all_preds[0], all_label[0]
+    accuracy = simple_accuracy(all_preds, all_label)
+
+    # logger.info("\n")
+    # logger.info("Validation Results")
+    # logger.info("Global Steps: %d" % global_step)
+    # logger.info("Valid Loss: %2.5f" % eval_losses.avg)
+    # logger.info("Valid Accuracy: %2.5f" % accuracy)
+
+    # use print instead of logger
+    print()
+    print("Validation Results")
+    print("Global Step: %d" % global_step)
+    print("Valid Loss: %2.5f" % eval_losses.avg)
+    print("Valid Accuracy: %2.5f" % accuracy)
+    #TODO
+    # add tensorboard
+    return accuracy
+        
+
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    # Required parameters
+    parser.add_argument("--name", required=True,
+                        help="Name of this run. Used for monitoring.")
+    parser.add_argument("--dataset", choices=["cifar10", "cifar100", "imagenet"], default="imagenet",
+                        help="Which downstream task.")
+    parser.add_argument("--data_path", type=str, default="/data/imagenet/ofrecord/",
+                        help="Which downstream task.")
+    parser.add_argument("--model_type", choices=["ViT-B_16", "ViT-B_32", "ViT-L_16",
+                                                 "ViT-L_32", "ViT-H_14", "R50-ViT-B_16"],
+                        default="ViT-B_16",
+                        help="Which variant to use.")
+    parser.add_argument("--pretrained_dir", type=str, default="/data/rentianhe/weight/vit_oneflow/ViT-B_16_oneflow",
+                        help="Where to search for pretrained ViT models.")
+    parser.add_argument("--output_dir", default="output", type=str,
+                        help="The output directory where checkpoints will be written.")
+    parser.add_argument("--img_size", default=224, type=int,
+                        help="Resolution size")
+    parser.add_argument("--train_batch_size", default=512, type=int,
+                        help="Total batch size for training.")
+    parser.add_argument("--eval_batch_size", default=32, type=int,
+                        help="Total batch size for eval.")
+    parser.add_argument("--eval_every", default=100, type=int,
+                        help="Run prediction on validation set every so many steps."
+                             "Will always run one evaluation at the end of training.")
+    parser.add_argument("--learning_rate", default=3e-2, type=float,
+                        help="The initial learning rate for SGD.")
+    parser.add_argument("--weight_decay", default=0, type=float,
+                        help="Weight deay if we apply some.")
+    parser.add_argument("--num_steps", default=20000, type=int,
+                        help="Total number of training epochs to perform.")
+    parser.add_argument("--decay_type", choices=["cosine", "linear"], default="cosine",
+                        help="How to decay the learning rate.")
+    parser.add_argument("--warmup_steps", default=500, type=int,
+                        help="Step of training to perform learning rate warmup for.")
+    parser.add_argument("--gradient_accumulation_steps", type=int, default=32,
+                        help="Number of updates steps to accumulate before performing a backward/update pass.")
+    parser.add_argument("--num_train_examples", type=int, default=1281167, 
+                        help="training picture number")
+    parser.add_argument("--num_val_examples", type=int, default=50000, 
+                        help="validation picture number")
+    args = parser.parse_args()
+
+
+    # model & criterion setup
+    args, model= setup(args)
+
+    # Training
+    train(args, model)
+
+if __name__ == "__main__":
+    main()
+

--- a/ViT/vit_oneflow_old/train.sh
+++ b/ViT/vit_oneflow_old/train.sh
@@ -1,0 +1,24 @@
+LEARNING_RATE=3e-2
+WEIGHT_DECAY=0.0
+DATA_PATH='/data/imagenet/ofrecord/'
+PRETRAINED_DIR="/data/rentianhe/weight/vit_oneflow/ViT-B_16_oneflow"
+TRAIN_BATCH_SIZE=512
+ACCU_STEPS=32
+EVAL_BATCH_SIZE=32
+NUM_STEPS=20000
+WARMUP_STEPS=500
+NAME='test'
+
+
+CUDA_VISIBLE_DEVICES=1 python3 train.py \
+    --learning_rate $LEARNING_RATE \
+    --weight_decay $WEIGHT_DECAY \
+    --data_path $DATA_PATH \
+    --pretrained_dir $PRETRAINED_DIR \
+    --gradient_accumulation_steps $ACCU_STEPS \
+    --num_steps $NUM_STEPS \
+    --warmup_steps $WARMUP_STEPS \
+    --train_batch_size $TRAIN_BATCH_SIZE \
+    --eval_batch_size $EVAL_BATCH_SIZE \
+    --name $NAME \
+

--- a/ViT/vit_oneflow_old/utils/lr_scheduler.py
+++ b/ViT/vit_oneflow_old/utils/lr_scheduler.py
@@ -1,0 +1,44 @@
+from oneflow.optim.lr_scheduler import LambdaLR
+import math
+
+class WarmupCosineSchedule(LambdaLR):
+    """ Linear warmup and then cosine decay.
+        Linearly increases learning rate from 0 to 1 over `warmup_steps` training steps.
+        Decreases learning rate from 1. to 0. over remaining `t_total - warmup_steps` steps following a cosine curve.
+        If `cycles` (default=0.5) is different from default, learning rate follows cosine function after warmup.
+    """
+    def __init__(self, optimizer, warmup_steps, t_total, cycles=.5, last_step=-1):
+        self.warmup_steps = warmup_steps
+        self.t_total = t_total
+        self.cycles = cycles
+        self.optimizer = optimizer
+        super(WarmupCosineSchedule, self).__init__(optimizer, self.lr_lambda, last_step=last_step)
+
+    def lr_lambda(self, step):
+        if step < self.warmup_steps:
+            return float(step) / float(max(1.0, self.warmup_steps))
+        # progress after warmup
+        progress = float(step - self.warmup_steps) / float(max(1, self.t_total - self.warmup_steps))
+        return max(0.0, 0.5 * (1. + math.cos(math.pi * float(self.cycles) * 2.0 * progress)))
+    
+    def get_step_values(self):
+        return self.optimizer.param_groups[0]['lr']
+
+class WarmupLinearSchedule(LambdaLR):
+    """ Linear warmup and then linear decay.
+        Linearly increases learning rate from 0 to 1 over `warmup_steps` training steps.
+        Linearly decreases learning rate from 1. to 0. over remaining `t_total - warmup_steps` steps.
+    """
+    def __init__(self, optimizer, warmup_steps, t_total, last_step=-1):
+        self.warmup_steps = warmup_steps
+        self.t_total = t_total
+        self.optimizer = optimizer
+        super(WarmupLinearSchedule, self).__init__(optimizer, self.lr_lambda, last_step=last_step)
+
+    def lr_lambda(self, step):
+        if step < self.warmup_steps:
+            return float(step) / float(max(1, self.warmup_steps))
+        return max(0.0, float(self.t_total - step) / float(max(1.0, self.t_total - self.warmup_steps)))
+    
+    def get_step_values(self):
+        return self.optimizer.param_groups[0]['lr']

--- a/ViT/vit_oneflow_old/utils/numpy_data_utils.py
+++ b/ViT/vit_oneflow_old/utils/numpy_data_utils.py
@@ -1,0 +1,61 @@
+from PIL import Image
+import numpy as np
+import os
+import random
+
+
+def load_image(image_path="data/fish.jpg"):
+    rgb_mean = [123.68, 116.779, 103.939]
+    rgb_std = [58.393, 57.12, 57.375]
+    im = Image.open(image_path)
+    im = im.resize((224, 224))
+    im = im.convert("RGB")
+    im = np.array(im).astype("float32")
+    im = (im - rgb_mean) / rgb_std
+    im = np.transpose(im, (2, 0, 1))
+    im = np.expand_dims(im, axis=0)
+    return np.ascontiguousarray(im, "float32")
+
+
+class NumpyDataLoader(object):
+    def __init__(self, dataset_root: str, batch_size: int = 1):
+        self.dataset_root = dataset_root
+        sub_folders = os.listdir(self.dataset_root)
+        self.image_2_class_label_list = []
+        self.label_2_class_name = {}
+        self.batch_size = batch_size
+
+        label = -1
+        for sf in sub_folders:
+            label += 1
+            self.label_2_class_name[label] = sf
+            sub_root = os.path.join(self.dataset_root, sf)
+            image_names = os.listdir(sub_root)
+            for name in image_names:
+                self.image_2_class_label_list.append(
+                    (os.path.join(sub_root, name), label)
+                )
+
+        self.curr_idx = 0
+        self.shuffle_data()
+
+    def shuffle_data(self):
+        random.shuffle(self.image_2_class_label_list)
+        self.curr_idx = 0
+
+    def __getitem__(self, index):
+        batch_datas = []
+        batch_labels = []
+        for i in range(self.batch_size):
+            image_path, label = self.image_2_class_label_list[self.curr_idx]
+            batch_datas.append(load_image(image_path))
+            batch_labels.append(int(label))
+            self.curr_idx += 1
+
+        np_datas = np.concatenate(tuple(batch_datas), axis=0)
+        np_labels = np.array(batch_labels, dtype=np.int32)
+
+        return np.ascontiguousarray(np_datas, "float32"), np_labels
+
+    def __len__(self):
+        return len(self.image_2_class_label_list) // self.batch_size

--- a/ViT/vit_oneflow_old/utils/ofrecord_data_utils.py
+++ b/ViT/vit_oneflow_old/utils/ofrecord_data_utils.py
@@ -1,0 +1,86 @@
+import oneflow as flow
+
+import os
+
+
+class OFRecordDataLoader(object):
+    def __init__(
+        self,
+        ofrecord_root: str = "./ofrecord",
+        mode: str = "train",  # "val"
+        dataset_size: int = 9469,
+        batch_size: int = 1,
+    ):
+        channel_last = False
+        output_layout = "NHWC" if channel_last else "NCHW"
+        self.train_record_reader = flow.nn.OfrecordReader(
+            os.path.join(ofrecord_root, mode),
+            batch_size=batch_size,
+            data_part_num=1,
+            part_name_suffix_length=5,
+            random_shuffle=True if mode == "train" else False,
+            shuffle_after_epoch=True if mode == "train" else False,
+        )
+        self.record_label_decoder = flow.nn.OfrecordRawDecoder(
+            "class/label", shape=(), dtype=flow.int32
+        )
+
+        color_space = "RGB"
+        height = 224
+        width = 224
+
+        self.record_image_decoder = (
+            flow.nn.OFRecordImageDecoderRandomCrop("encoded", color_space=color_space)
+            if mode == "train"
+            else flow.nn.OFRecordImageDecoder("encoded", color_space=color_space)
+        )
+
+        self.resize = (
+            flow.nn.image.Resize(target_size=[height, width])
+            if mode == "train"
+            else flow.nn.image.Resize(
+                resize_side="shorter", keep_aspect_ratio=True, target_size=256
+            )
+        )
+
+        self.flip = flow.nn.CoinFlip(batch_size=batch_size) if mode == "train" else None
+
+        rgb_mean = [123.68, 116.779, 103.939]
+        rgb_std = [58.393, 57.12, 57.375]
+        self.crop_mirror_norm = (
+            flow.nn.CropMirrorNormalize(
+                color_space=color_space,
+                output_layout=output_layout,
+                mean=rgb_mean,
+                std=rgb_std,
+                output_dtype=flow.float,
+            )
+            if mode == "train"
+            else flow.nn.CropMirrorNormalize(
+                color_space=color_space,
+                output_layout=output_layout,
+                crop_h=height,
+                crop_w=width,
+                crop_pos_y=0.5,
+                crop_pos_x=0.5,
+                mean=rgb_mean,
+                std=rgb_std,
+                output_dtype=flow.float,
+            )
+        )
+
+        self.batch_size = batch_size
+        self.dataset_size = dataset_size
+
+    def __len__(self):
+        return self.dataset_size // self.batch_size
+
+    def get_batch(self):
+        train_record = self.train_record_reader()
+        label = self.record_label_decoder(train_record)
+        image_raw_buffer = self.record_image_decoder(train_record)
+        image = self.resize(image_raw_buffer)
+        rng = self.flip() if self.flip != None else None
+        image = self.crop_mirror_norm(image[0], rng)
+
+        return image, label

--- a/ViT/vit_pytorch/checkpoint.py
+++ b/ViT/vit_pytorch/checkpoint.py
@@ -1,0 +1,120 @@
+import os
+import torch
+from tensorflow.io import gfile
+import numpy as np
+
+
+def load_checkpoint(path):
+    """ Load weights from a given checkpoint path in npz/pth """
+    if path.endswith('npz'):
+        keys, values = load_jax(path)
+        state_dict = convert_jax_pytorch(keys, values)
+    elif path.endswith('pth'):
+        state_dict = torch.load(path)['state_dict']
+    else:
+        raise ValueError("checkpoint format {} not supported yet!".format(path.split('.')[-1]))
+
+    return state_dict
+
+
+def load_jax(path):
+    """ Loads params from a npz checkpoint previously stored with `save()` in jax implemetation """
+    with gfile.GFile(path, 'rb') as f:
+        ckpt_dict = np.load(f, allow_pickle=False)
+        keys, values = zip(*list(ckpt_dict.items()))
+    return keys, values
+
+
+def save_jax_to_pytorch(jax_path, save_path):
+    model_name = jax_path.split('/')[-1].split('.')[0]
+    keys, values = load_jax(jax_path)
+    state_dict = convert_jax_pytorch(keys, values)
+    checkpoint = {'state_dict': state_dict}
+    torch.save(checkpoint, os.path.join(save_path, model_name + '.pth'))
+
+
+def replace_names(names):
+    """ Replace jax model names with pytorch model names """
+    new_names = []
+    for name in names:
+        if name == 'Transformer':
+            new_names.append('transformer')
+        elif name == 'encoder_norm':
+            new_names.append('norm')
+        elif 'encoderblock' in name:
+            num = name.split('_')[-1]
+            new_names.append('encoder_layers')
+            new_names.append(num)
+        elif 'LayerNorm' in name:
+            num = name.split('_')[-1]
+            if num == '0':
+                new_names.append('norm{}'.format(1))
+            elif num == '2':
+                new_names.append('norm{}'.format(2))
+        elif 'MlpBlock' in name:
+            new_names.append('mlp')
+        elif 'Dense' in name:
+            num = name.split('_')[-1]
+            new_names.append('fc{}'.format(int(num) + 1))
+        elif 'MultiHeadDotProductAttention' in name:
+            new_names.append('attn')
+        elif name == 'kernel' or name == 'scale':
+            new_names.append('weight')
+        elif name == 'bias':
+            new_names.append(name)
+        elif name == 'posembed_input':
+            new_names.append('pos_embedding')
+        elif name == 'pos_embedding':
+            new_names.append('pos_embedding')
+        elif name == 'embedding':
+            new_names.append('embedding')
+        elif name == 'head':
+            new_names.append('classifier')
+        elif name == 'cls':
+            new_names.append('cls_token')
+        else:
+            new_names.append(name)
+    return new_names
+
+
+def convert_jax_pytorch(keys, values):
+    """ Convert jax model parameters with pytorch model parameters """
+    state_dict = {}
+    for key, value in zip(keys, values):
+
+        # convert name to torch names
+        names = key.split('/')
+        torch_names = replace_names(names)
+        torch_key = '.'.join(w for w in torch_names)
+
+        # convert values to tensor and check shapes
+        tensor_value = torch.tensor(value, dtype=torch.float)
+        # check shape
+        num_dim = len(tensor_value.shape)
+
+        if num_dim == 1:
+            tensor_value = tensor_value.squeeze()
+        elif num_dim == 2 and torch_names[-1] == 'weight':
+            # for normal weight, transpose it
+            tensor_value = tensor_value.T
+        elif num_dim == 3 and torch_names[-1] == 'weight' and torch_names[-2] in ['query', 'key', 'value']:
+            feat_dim, num_heads, head_dim = tensor_value.shape
+            # for multi head attention q/k/v weight
+            tensor_value = tensor_value
+        elif num_dim == 2 and torch_names[-1] == 'bias' and torch_names[-2] in ['query', 'key', 'value']:
+            # for multi head attention q/k/v bias
+            tensor_value = tensor_value
+        elif num_dim == 3 and torch_names[-1] == 'weight' and torch_names[-2] == 'out':
+            # for multi head attention out weight
+            tensor_value = tensor_value
+        elif num_dim == 4 and torch_names[-1] == 'weight':
+            tensor_value = tensor_value.permute(3, 2, 0, 1)
+
+        # print("{}: {}".format(torch_key, tensor_value.shape))
+        state_dict[torch_key] = tensor_value
+    return state_dict
+
+
+if __name__ == '__main__':
+    save_jax_to_pytorch('/Users/leon/Downloads/jax/imagenet21k+imagenet2012_ViT-L_16-224.npz', '/Users/leon/Downloads/pytorch')
+

--- a/ViT/vit_pytorch/checkpoint_new.py
+++ b/ViT/vit_pytorch/checkpoint_new.py
@@ -1,0 +1,122 @@
+import os
+import torch
+from tensorflow.io import gfile
+import numpy as np
+
+
+def load_checkpoint(path, config):
+    """ Load weights from a given checkpoint path in npz/pth """
+    if path.endswith('npz'):
+        keys, values = load_jax(path)
+        state_dict = convert_jax_pytorch(keys, values, config)
+    elif path.endswith('pth'):
+        state_dict = torch.load(path)['state_dict']
+    else:
+        raise ValueError("checkpoint format {} not supported yet!".format(path.split('.')[-1]))
+
+    return state_dict
+
+
+def load_jax(path):
+    """ Loads params from a npz checkpoint previously stored with `save()` in jax implemetation """
+    with gfile.GFile(path, 'rb') as f:
+        ckpt_dict = np.load(f, allow_pickle=False)
+        keys, values = zip(*list(ckpt_dict.items()))
+    return keys, values
+
+
+def save_jax_to_pytorch(jax_path, save_path, config):
+    model_name = jax_path.split('/')[-1].split('.')[0]
+    keys, values = load_jax(jax_path)
+    state_dict = convert_jax_pytorch(keys, values, config)
+    checkpoint = {'state_dict': state_dict}
+    torch.save(checkpoint, os.path.join(save_path, model_name + '.pth'))
+
+
+def replace_names(names):
+    """ Replace jax model names with pytorch model names """
+    new_names = []
+    for name in names:
+        if name == 'Transformer':
+            new_names.append('transformer')
+        elif name == 'encoder_norm':
+            new_names.append('norm')
+        elif 'encoderblock' in name:
+            num = name.split('_')[-1]
+            new_names.append('encoder_layers')
+            new_names.append(num)
+        elif 'LayerNorm' in name:
+            num = name.split('_')[-1]
+            if num == '0':
+                new_names.append('norm{}'.format(1))
+            elif num == '2':
+                new_names.append('norm{}'.format(2))
+        elif 'MlpBlock' in name:
+            new_names.append('mlp')
+        elif 'Dense' in name:
+            num = name.split('_')[-1]
+            new_names.append('fc{}'.format(int(num) + 1))
+        elif 'MultiHeadDotProductAttention' in name:
+            new_names.append('attn')
+        elif name == 'kernel' or name == 'scale':
+            new_names.append('weight')
+        elif name == 'bias':
+            new_names.append(name)
+        elif name == 'posembed_input':
+            new_names.append('pos_embedding')
+        elif name == 'pos_embedding':
+            new_names.append('pos_embedding')
+        elif name == 'embedding':
+            new_names.append('embedding')
+        elif name == 'head':
+            new_names.append('classifier')
+        elif name == 'cls':
+            new_names.append('cls_token')
+        else:
+            new_names.append(name)
+    return new_names
+
+
+def convert_jax_pytorch(keys, values, config):
+    """ Convert jax model parameters with pytorch model parameters """
+    state_dict = {}
+    for key, value in zip(keys, values):
+
+        # convert name to torch names
+        names = key.split('/')
+        torch_names = replace_names(names)
+        torch_key = '.'.join(w for w in torch_names)
+
+        # convert values to tensor and check shapes
+        tensor_value = torch.tensor(value, dtype=torch.float)
+        # check shape
+        num_dim = len(tensor_value.shape)
+
+        if num_dim == 1:
+            tensor_value = tensor_value.squeeze()
+        elif num_dim == 2 and torch_names[-1] == 'weight':
+            # for normal weight, transpose it
+            tensor_value = tensor_value.T
+        elif num_dim == 3 and torch_names[-1] == 'weight' and torch_names[-2] in ['query', 'key', 'value']:
+            feat_dim, num_heads, head_dim = tensor_value.shape
+            # for multi head attention q/k/v weight
+            # tensor_value = tensor_value
+            tensor_value = tensor_value.view(config.emb_dim, config.emb_dim).t()
+        elif num_dim == 2 and torch_names[-1] == 'bias' and torch_names[-2] in ['query', 'key', 'value']:
+            # for multi head attention q/k/v bias
+            tensor_value = tensor_value
+        elif num_dim == 3 and torch_names[-1] == 'weight' and torch_names[-2] == 'out':
+            # for multi head attention out weight
+            # tensor_value = tensor_value
+            tensor_value = tensor_value.view(config.emb_dim, config.emb_dim).t()
+        elif num_dim == 4 and torch_names[-1] == 'weight':
+            tensor_value = tensor_value.permute(3, 2, 0, 1)
+
+        # print("{}: {}".format(torch_key, tensor_value.shape))
+        state_dict[torch_key] = tensor_value
+    return state_dict
+
+
+if __name__ == '__main__':
+    save_jax_to_pytorch('/Users/leon/Downloads/jax/imagenet21k+imagenet2012_ViT-L_16-224.npz', '/Users/leon/Downloads/pytorch')
+

--- a/ViT/vit_pytorch/checkpoint_torch.py
+++ b/ViT/vit_pytorch/checkpoint_torch.py
@@ -1,0 +1,59 @@
+import torch
+
+checkpoint_path = "/data/rentianhe/code/ViT-OneFlow/models/ViT/weights/checkpoint/imagenet21k+imagenet2012_ViT-B_16.pth"
+
+def load_checkpoint(path):
+    state_dict = torch.load(path)['state_dict']
+    keys, values = zip(*list(state_dict.items()))
+    state_dict = convert_torch_weight(keys, values)
+    return state_dict
+
+def convert_torch_weight(keys, values):
+    """ Convert jax model parameters with pytorch model parameters """
+    state_dict = {}
+    for key, value in zip(keys, values):
+
+        # convert name to torch names
+        names = key.split('.')
+        torch_names = names
+        # torch_names = replace_names(names)
+        torch_key = key
+
+        # convert values to tensor and check shapes
+        tensor_value = value
+        # check shape
+        num_dim = len(tensor_value.shape)
+
+        if num_dim == 1:
+            tensor_value = tensor_value.squeeze()
+        elif num_dim == 2 and torch_names[-1] == 'weight':
+            # for normal weight, transpose it
+            tensor_value = tensor_value
+        elif num_dim == 3 and torch_names[-1] == 'weight' and torch_names[-2] in ['query', 'key', 'value']:
+            feat_dim, num_heads, head_dim = tensor_value.shape
+            # for multi head attention q/k/v weight
+            dim, head, head_dim = tensor_value.shape
+            tensor_value = tensor_value.view(dim, head * head_dim).t()
+        elif num_dim == 2 and torch_names[-1] == 'bias' and torch_names[-2] in ['query', 'key', 'value']:
+            # for multi head attention q/k/v bias
+            tensor_value = tensor_value.view(-1)
+        elif num_dim == 3 and torch_names[-1] == 'weight' and torch_names[-2] == 'out':
+            # for multi head attention out weight
+            head, head_dim, dim = tensor_value.shape
+            tensor_value = tensor_value.view(head * head_dim, dim).t()
+        elif num_dim == 4 and torch_names[-1] == 'weight':
+            tensor_value = tensor_value
+
+        # print("{}: {}".format(torch_key, tensor_value.shape))
+        state_dict[torch_key] = tensor_value
+    return state_dict
+
+# print(load_checkpoint(checkpoint_path))
+if __name__ == "__main__":
+    state_dict = load_checkpoint(checkpoint_path)
+    # for key, value in zip(keys, values):
+    #     print(value.size())
+    # for value in state_dict[1]:
+    #     print(value.shape)
+    for key in state_dict.keys():
+        print(state_dict[key].shape)

--- a/ViT/vit_pytorch/config.py
+++ b/ViT/vit_pytorch/config.py
@@ -1,0 +1,112 @@
+import argparse
+from utils import process_config
+
+
+def get_eval_config():
+    parser = argparse.ArgumentParser("Visual Transformer Evaluation")
+
+    # basic config
+    parser.add_argument("--n-gpu", type=int, default=1, help="number of gpus to use")
+    parser.add_argument("--model-arch", type=str, default="b16", help='model setting to use', choices=['b16', 'b32', 'l16', 'l32', 'h14'])
+    parser.add_argument("--checkpoint-path", type=str, default=None, help="model checkpoint to load weights")
+    parser.add_argument("--image-size", type=int, default=384, help="input image size", choices=[224, 384])
+    parser.add_argument("--batch-size", type=int, default=32, help="batch size")
+    parser.add_argument("--num-workers", type=int, default=8, help="number of workers")
+    parser.add_argument("--data-dir", type=str, default='../data', help='data folder')
+    parser.add_argument("--dataset", type=str, default='ImageNet', help="dataset for fine-tunning/evaluation")
+    parser.add_argument("--num-classes", type=int, default=1000, help="number of classes in dataset")
+    config = parser.parse_args()
+
+    # model config
+    config = eval("get_{}_config".format(config.model_arch))(config)
+
+    print_config(config)
+    return config
+
+
+def get_train_config():
+    parser = argparse.ArgumentParser("Visual Transformer Train/Fine-tune")
+
+    # basic config
+    parser.add_argument("--exp-name", type=str, default="ft", help="experiment name")
+    parser.add_argument("--n-gpu", type=int, default=1, help="number of gpus to use")
+    parser.add_argument("--tensorboard", default=False, action='store_true', help='flag of turnning on tensorboard')
+    parser.add_argument("--model-arch", type=str, default="b16", help='model setting to use', choices=['b16', 'b32', 'l16', 'l32', 'h14'])
+    parser.add_argument("--checkpoint-path", type=str, default=None, help="model checkpoint to load weights")
+    parser.add_argument("--image-size", type=int, default=384, help="input image size", choices=[224, 384])
+    parser.add_argument("--batch-size", type=int, default=32, help="batch size")
+    parser.add_argument("--num-workers", type=int, default=8, help="number of workers")
+    parser.add_argument("--train-steps", type=int, default=10000, help="number of training/fine-tunning steps")
+    parser.add_argument("--lr", type=float, default=1e-3, help="learning rate")
+    parser.add_argument("--wd", type=float, default=1e-4, help='weight decay')
+    parser.add_argument("--warmup-steps", type=int, default=500, help='learning rate warm up steps')
+    parser.add_argument("--data-dir", type=str, default='../data', help='data folder')
+    parser.add_argument("--dataset", type=str, default='ImageNet', help="dataset for fine-tunning/evaluation")
+    parser.add_argument("--num-classes", type=int, default=1000, help="number of classes in dataset")
+    config = parser.parse_args()
+
+    # model config
+    config = eval("get_{}_config".format(config.model_arch))(config)
+    process_config(config)
+    print_config(config)
+    return config
+
+
+def get_b16_config(config):
+    """ ViT-B/16 configuration """
+    config.patch_size = 16
+    config.emb_dim = 768
+    config.mlp_dim = 3072
+    config.num_heads = 12
+    config.num_layers = 12
+    config.attn_dropout_rate = 0.0
+    config.dropout_rate = 0.1
+    return config
+
+
+def get_b32_config(config):
+    """ ViT-B/32 configuration """
+    config = get_b16_config(config)
+    config.patch_size = 32
+    return config
+
+
+def get_l16_config(config):
+    """ ViT-L/16 configuration """
+    config.patch_size = 16
+    config.emb_dim = 1024
+    config.mlp_dim = 4096
+    config.num_heads = 16
+    config.num_layers = 24
+    config.attn_dropout_rate = 0.0
+    config.dropout_rate = 0.1
+    return config
+
+
+def get_l32_config(config):
+    """ Vit-L/32 configuration """
+    config = get_l16_config(config)
+    config.patch_size = 32
+    return config
+
+
+def get_h14_config(config):
+    """  ViT-H/14 configuration """
+    config.patch_size = 14
+    config.emb_dim = 1280
+    config.mlp_dim = 5120
+    config.num_heads = 16
+    config.num_layers = 32
+    config.attn_dropout_rate = 0.0
+    config.dropout_rate = 0.1
+    return config
+
+
+def print_config(config):
+    message = ''
+    message += '----------------- Config ---------------\n'
+    for k, v in sorted(vars(config).items()):
+        comment = ''
+        message += '{:>35}: {:<30}{}\n'.format(str(k), str(v), comment)
+    message += '----------------- End -------------------'
+    print(message)

--- a/ViT/vit_pytorch/data_loaders.py
+++ b/ViT/vit_pytorch/data_loaders.py
@@ -1,0 +1,98 @@
+import os
+from torch.utils.data import DataLoader
+from torchvision.datasets import CIFAR10, CIFAR100, ImageFolder
+from torchvision.transforms import transforms
+
+
+__all__ = ['CIFAR10DataLoader', 'ImageNetDataLoader', 'CIFAR100DataLoader']
+
+
+class CIFAR10DataLoader(DataLoader):
+    def __init__(self, data_dir, split='train', image_size=224, batch_size=16, num_workers=8):
+        if split == 'train':
+            train = True
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+        else:
+            train = False
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+
+        self.dataset = CIFAR10(root=data_dir, train=train, transform=transform, download=True)
+
+        super(CIFAR10DataLoader, self).__init__(
+            dataset=self.dataset,
+            batch_size=batch_size,
+            shuffle=False if not train else True,
+            num_workers=num_workers)
+
+
+class CIFAR100DataLoader(DataLoader):
+    def __init__(self, data_dir, split='train', image_size=224, batch_size=16, num_workers=8):
+        if split == 'train':
+            train = True
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+        else:
+            train = False
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+
+        self.dataset = CIFAR100(root=data_dir, train=train, transform=transform, download=True)
+
+        super(CIFAR100DataLoader, self).__init__(
+            dataset=self.dataset,
+            batch_size=batch_size,
+            shuffle=False if not train else True,
+            num_workers=num_workers)
+
+
+class ImageNetDataLoader(DataLoader):
+    def __init__(self, data_dir, split='train', image_size=224, batch_size=16, num_workers=8):
+
+        if split == 'train':
+            transform = transforms.Compose([
+                transforms.Resize((image_size, image_size)),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+        else:
+            transform = transforms.Compose([
+                transforms.Resize((image_size, image_size)),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+
+        self.dataset = ImageFolder(root=os.path.join(data_dir, split), transform=transform)
+        super(ImageNetDataLoader, self).__init__(
+            dataset=self.dataset,
+            batch_size=batch_size,
+            shuffle=True if split == 'train' else False,
+            num_workers=num_workers)
+
+
+if __name__ == '__main__':
+    data_loader = ImageNetDataLoader(
+        data_dir='/data/imagenet/extract',
+        split='val',
+        image_size=384,
+        batch_size=16,
+        num_workers=8)
+
+    for images, targets in data_loader:
+        print(targets)

--- a/ViT/vit_pytorch/eval.py
+++ b/ViT/vit_pytorch/eval.py
@@ -1,0 +1,77 @@
+import os
+import torch
+import numpy as np
+from tqdm import tqdm
+from model import VisionTransformer
+from config import get_eval_config
+from checkpoint import load_checkpoint
+from data_loaders import *
+from utils import accuracy, setup_device
+
+
+def main():
+
+    config = get_eval_config()
+    config.checkpoint_path = "/data/rentianhe/code/ViT-OneFlow/models/ViT/weights/checkpoint/imagenet21k+imagenet2012_ViT-B_16.pth"
+    # device
+    device, device_ids = setup_device(config.n_gpu)
+
+    # create model
+    model = VisionTransformer(
+             image_size=(config.image_size, config.image_size),
+             patch_size=(config.patch_size, config.patch_size),
+             emb_dim=config.emb_dim,
+             mlp_dim=config.mlp_dim,
+             num_heads=config.num_heads,
+             num_layers=config.num_layers,
+             num_classes=config.num_classes,
+             attn_dropout_rate=config.attn_dropout_rate,
+             dropout_rate=config.dropout_rate)
+
+    # load checkpoint
+    if config.checkpoint_path:
+        state_dict = load_checkpoint(config.checkpoint_path)
+        model.load_state_dict(state_dict)
+        print("Load pretrained weights from {}".format(config.checkpoint_path))
+
+    # send model to device
+    model = model.to(device)
+    if len(device_ids) > 1:
+        model = torch.nn.DataParallel(model, device_ids=device_ids)
+
+    # create dataloader
+    data_loader = eval("{}DataLoader".format(config.dataset))(
+                    # data_dir=os.path.join(config.data_dir, config.dataset),
+                    data_dir = "/data/imagenet/extract",
+                    image_size=config.image_size,
+                    batch_size=config.batch_size,
+                    num_workers=config.num_workers,
+                    split='val')
+    total_batch = len(data_loader)
+
+    # starting evaluation
+    print("Starting evaluation")
+    acc1s = []
+    acc5s = []
+    model.eval()
+    with torch.no_grad():
+        pbar = tqdm(enumerate(data_loader), total=total_batch)
+        for batch_idx, (data, target) in pbar:
+            pbar.set_description("Batch {:05d}/{:05d}".format(batch_idx, total_batch))
+
+            data = data.to(device)
+            target = target.to(device)
+
+            pred_logits = model(data)
+            acc1, acc5 = accuracy(pred_logits, target, topk=(1, 5))
+
+            acc1s.append(acc1.item())
+            acc5s.append(acc5.item())
+
+            pbar.set_postfix(acc1=acc1.item(), acc5=acc5.item())
+
+    print("Evaluation of model {:s} on dataset {:s}, Acc@1: {:.4f}, Acc@5: {:.4f}".format(config.model_arch, config.dataset, np.mean(acc1s), np.mean(acc5s)))
+
+
+if __name__ == '__main__':
+    main()

--- a/ViT/vit_pytorch/eval_new.py
+++ b/ViT/vit_pytorch/eval_new.py
@@ -1,0 +1,77 @@
+import os
+import torch
+import numpy as np
+from tqdm import tqdm
+from model_new import VisionTransformer
+from config import get_eval_config
+from checkpoint_torch import load_checkpoint
+from data_loaders import *
+from utils import accuracy, setup_device
+
+
+def main():
+
+    config = get_eval_config()
+    config.checkpoint_path = "/data/rentianhe/code/ViT-OneFlow/models/ViT/weights/checkpoint/imagenet21k+imagenet2012_ViT-B_16.pth"
+    # device
+    device, device_ids = setup_device(config.n_gpu)
+
+    # create model
+    model = VisionTransformer(
+             image_size=(config.image_size, config.image_size),
+             patch_size=(config.patch_size, config.patch_size),
+             emb_dim=config.emb_dim,
+             mlp_dim=config.mlp_dim,
+             num_heads=config.num_heads,
+             num_layers=config.num_layers,
+             num_classes=config.num_classes,
+             attn_dropout_rate=config.attn_dropout_rate,
+             dropout_rate=config.dropout_rate)
+
+    # load checkpoint
+    if config.checkpoint_path:
+        state_dict = load_checkpoint(config.checkpoint_path)
+        model.load_state_dict(state_dict)
+        print("Load pretrained weights from {}".format(config.checkpoint_path))
+
+    # send model to device
+    model = model.to(device)
+    if len(device_ids) > 1:
+        model = torch.nn.DataParallel(model, device_ids=device_ids)
+
+    # create dataloader
+    data_loader = eval("{}DataLoader".format(config.dataset))(
+                    # data_dir=os.path.join(config.data_dir, config.dataset),
+                    data_dir = "/data/imagenet/extract",
+                    image_size=config.image_size,
+                    batch_size=config.batch_size,
+                    num_workers=config.num_workers,
+                    split='val')
+    total_batch = len(data_loader)
+
+    # starting evaluation
+    print("Starting evaluation")
+    acc1s = []
+    acc5s = []
+    model.eval()
+    with torch.no_grad():
+        pbar = tqdm(enumerate(data_loader), total=total_batch)
+        for batch_idx, (data, target) in pbar:
+            pbar.set_description("Batch {:05d}/{:05d}".format(batch_idx, total_batch))
+
+            data = data.to(device)
+            target = target.to(device)
+
+            pred_logits = model(data)
+            acc1, acc5 = accuracy(pred_logits, target, topk=(1, 5))
+
+            acc1s.append(acc1.item())
+            acc5s.append(acc5.item())
+
+            pbar.set_postfix(acc1=acc1.item(), acc5=acc5.item())
+
+    print("Evaluation of model {:s} on dataset {:s}, Acc@1: {:.4f}, Acc@5: {:.4f}".format(config.model_arch, config.dataset, np.mean(acc1s), np.mean(acc5s)))
+
+
+if __name__ == '__main__':
+    main()

--- a/ViT/vit_pytorch/model.py
+++ b/ViT/vit_pytorch/model.py
@@ -1,0 +1,219 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import numpy as np
+
+
+class PositionEmbs(nn.Module):
+    def __init__(self, num_patches, emb_dim, dropout_rate=0.1):
+        super(PositionEmbs, self).__init__()
+        self.pos_embedding = nn.Parameter(torch.randn(1, num_patches + 1, emb_dim))
+        if dropout_rate > 0:
+            self.dropout = nn.Dropout(dropout_rate)
+        else:
+            self.dropout = None
+
+    def forward(self, x):
+        out = x + self.pos_embedding
+
+        if self.dropout:
+            out = self.dropout(out)
+
+        return out
+
+
+class MlpBlock(nn.Module):
+    """ Transformer Feed-Forward Block """
+    def __init__(self, in_dim, mlp_dim, out_dim, dropout_rate=0.1):
+        super(MlpBlock, self).__init__()
+
+        # init layers
+        self.fc1 = nn.Linear(in_dim, mlp_dim)
+        self.fc2 = nn.Linear(mlp_dim, out_dim)
+        self.act = nn.GELU()
+        if dropout_rate > 0.0:
+            self.dropout1 = nn.Dropout(dropout_rate)
+            self.dropout2 = nn.Dropout(dropout_rate)
+        else:
+            self.dropout1 = None
+            self.dropout2 = None
+
+    def forward(self, x):
+
+        out = self.fc1(x)
+        out = self.act(out)
+        if self.dropout1:
+            out = self.dropout1(out)
+
+        out = self.fc2(out)
+        out = self.dropout2(out)
+        return out
+
+
+class LinearGeneral(nn.Module):
+    def __init__(self, in_dim=(768,), feat_dim=(12, 64)):
+        super(LinearGeneral, self).__init__()
+
+        self.weight = nn.Parameter(torch.randn(*in_dim, *feat_dim))
+        self.bias = nn.Parameter(torch.zeros(*feat_dim))
+
+    def forward(self, x, dims):
+        a = torch.tensordot(x, self.weight, dims=dims) + self.bias
+        return a
+
+
+class SelfAttention(nn.Module):
+    def __init__(self, in_dim, heads=8, dropout_rate=0.1):
+        super(SelfAttention, self).__init__()
+        self.heads = heads
+        self.head_dim = in_dim // heads
+        self.scale = self.head_dim ** 0.5
+
+        self.query = LinearGeneral((in_dim,), (self.heads, self.head_dim))
+        self.key = LinearGeneral((in_dim,), (self.heads, self.head_dim))
+        self.value = LinearGeneral((in_dim,), (self.heads, self.head_dim))
+        self.out = LinearGeneral((self.heads, self.head_dim), (in_dim,))
+
+        if dropout_rate > 0:
+            self.dropout = nn.Dropout(dropout_rate)
+        else:
+            self.dropout = None
+
+    def forward(self, x):
+        b, n, _ = x.shape
+        q = self.query(x, dims=([2], [0]))
+        k = self.key(x, dims=([2], [0]))
+        v = self.value(x, dims=([2], [0]))
+
+        q = q.permute(0, 2, 1, 3)
+        k = k.permute(0, 2, 1, 3)
+        v = v.permute(0, 2, 1, 3)
+
+        attn_weights = torch.matmul(q, k.transpose(-2, -1)) / self.scale
+        attn_weights = F.softmax(attn_weights, dim=-1)
+        out = torch.matmul(attn_weights, v)
+        out = out.permute(0, 2, 1, 3)
+
+        out = self.out(out, dims=([2, 3], [0, 1]))
+
+        return out
+
+
+class EncoderBlock(nn.Module):
+    def __init__(self, in_dim, mlp_dim, num_heads, dropout_rate=0.1, attn_dropout_rate=0.1):
+        super(EncoderBlock, self).__init__()
+
+        self.norm1 = nn.LayerNorm(in_dim)
+        self.attn = SelfAttention(in_dim, heads=num_heads, dropout_rate=attn_dropout_rate)
+        if dropout_rate > 0:
+            self.dropout = nn.Dropout(dropout_rate)
+        else:
+            self.dropout = None
+        self.norm2 = nn.LayerNorm(in_dim)
+        self.mlp = MlpBlock(in_dim, mlp_dim, in_dim, dropout_rate)
+
+    def forward(self, x):
+        residual = x
+        out = self.norm1(x)
+        out = self.attn(out)
+        if self.dropout:
+            out = self.dropout(out)
+        out += residual
+        residual = out
+
+        out = self.norm2(out)
+        out = self.mlp(out)
+        out += residual
+        return out
+
+
+class Encoder(nn.Module):
+    def __init__(self, num_patches, emb_dim, mlp_dim, num_layers=12, num_heads=12, dropout_rate=0.1, attn_dropout_rate=0.0):
+        super(Encoder, self).__init__()
+
+        # positional embedding
+        self.pos_embedding = PositionEmbs(num_patches, emb_dim, dropout_rate)
+
+        # encoder blocks
+        in_dim = emb_dim
+        self.encoder_layers = nn.ModuleList()
+        for i in range(num_layers):
+            layer = EncoderBlock(in_dim, mlp_dim, num_heads, dropout_rate, attn_dropout_rate)
+            self.encoder_layers.append(layer)
+        self.norm = nn.LayerNorm(in_dim)
+
+    def forward(self, x):
+
+        out = self.pos_embedding(x)
+
+        for layer in self.encoder_layers:
+            out = layer(out)
+
+        out = self.norm(out)
+        return out
+
+
+class VisionTransformer(nn.Module):
+    """ Vision Transformer """
+    def __init__(self,
+                 image_size=(256, 256),
+                 patch_size=(16, 16),
+                 emb_dim=768,
+                 mlp_dim=3072,
+                 num_heads=12,
+                 num_layers=12,
+                 num_classes=1000,
+                 attn_dropout_rate=0.0,
+                 dropout_rate=0.1,
+                 feat_dim=None):
+        super(VisionTransformer, self).__init__()
+        h, w = image_size
+
+        # embedding layer
+        fh, fw = patch_size
+        gh, gw = h // fh, w // fw
+        num_patches = gh * gw
+        self.embedding = nn.Conv2d(3, emb_dim, kernel_size=(fh, fw), stride=(fh, fw))
+        # class token
+        self.cls_token = nn.Parameter(torch.zeros(1, 1, emb_dim))
+
+        # transformer
+        self.transformer = Encoder(
+            num_patches=num_patches,
+            emb_dim=emb_dim,
+            mlp_dim=mlp_dim,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            dropout_rate=dropout_rate,
+            attn_dropout_rate=attn_dropout_rate)
+
+        # classfier
+        self.classifier = nn.Linear(emb_dim, num_classes)
+
+    def forward(self, x):
+        emb = self.embedding(x)     # (n, c, gh, gw)
+        emb = emb.permute(0, 2, 3, 1)  # (n, gh, hw, c)
+        b, h, w, c = emb.shape
+        emb = emb.reshape(b, h * w, c)
+
+        # prepend class token
+        cls_token = self.cls_token.repeat(b, 1, 1)
+        emb = torch.cat([cls_token, emb], dim=1)
+
+        # transformer
+        feat = self.transformer(emb)
+
+        # classifier
+        logits = self.classifier(feat[:, 0])
+        return logits
+
+
+if __name__ == '__main__':
+    model = VisionTransformer(num_layers=2)
+    x = torch.randn((2, 3, 256, 256))
+    out = model(x)
+
+    state_dict = model.state_dict()
+
+    for key, value in state_dict.items():
+        print("{}: {}".format(key, value.shape))

--- a/ViT/vit_pytorch/utils.py
+++ b/ViT/vit_pytorch/utils.py
@@ -1,0 +1,174 @@
+import os
+import json
+import pandas as pd
+import torch
+from pathlib import Path
+from collections import OrderedDict
+from datetime import datetime
+import importlib
+
+def ensure_dir(dirname):
+    dirname = Path(dirname)
+    if not dirname.is_dir():
+        dirname.mkdir(parents=True, exist_ok=False)
+
+
+def read_json(fname):
+    fname = Path(fname)
+    with fname.open('rt') as handle:
+        return json.load(handle, object_hook=OrderedDict)
+
+
+def write_json(content, fname):
+    fname = Path(fname)
+    with fname.open('wt') as handle:
+        json.dump(content, handle, indent=4, sort_keys=False)
+
+
+def accuracy(output, target, topk=(1,)):
+    """Computes the precision@k for the specified values of k"""""
+    maxk = max(topk)
+    batch_size = target.size(0)
+
+    _, pred = output.topk(maxk, 1, True, True)
+    pred = pred.t()
+    correct = pred.eq(target.view(1, -1).expand_as(pred))
+
+    res = []
+    for k in topk:
+        correct_k = correct[:k].contiguous().view(-1).float().sum(0)
+        res.append(correct_k / batch_size * 100.0)
+    return res
+
+
+def setup_device(n_gpu_use):
+    n_gpu = torch.cuda.device_count()
+    if n_gpu_use > 0 and n_gpu == 0:
+        print("Warning: There\'s no GPU available on this machine, training will be performed on CPU.")
+        n_gpu_use = 0
+    if n_gpu_use > n_gpu:
+        print("Warning: The number of GPU\'s configured to use is {}, but only {} are available on this machine.".format(n_gpu_use, n_gpu))
+        n_gpu_use = n_gpu
+    device = torch.device('cuda:0' if n_gpu_use > 0 else 'cpu')
+    list_ids = list(range(n_gpu_use))
+    return device, list_ids
+
+def process_config(config):
+    print(' *************************************** ')
+    print(' The experiment name is {} '.format(config.exp_name))
+    print(' *************************************** ')
+
+    # add datetime postfix
+    timestamp = datetime.now().strftime('%y%m%d_%H%M%S')
+    exp_name = config.exp_name + '_{}_bs{}_lr{}_wd{}'.format(config.dataset, config.batch_size, config.lr, config.wd)
+    exp_name += ('_' + timestamp)
+
+    # create some important directories to be used for that experiments
+    config.summary_dir = os.path.join('experiments', 'tb', exp_name)
+    config.checkpoint_dir = os.path.join('experiments', 'save', exp_name, 'checkpoints/')
+    config.result_dir = os.path.join('experiments', 'save', exp_name, 'results/')
+    for dir in [config.summary_dir, config.checkpoint_dir, config.result_dir]:
+        ensure_dir(dir)
+
+    # save config
+    write_json(vars(config), os.path.join('experiments', 'save', exp_name, 'config.json'))
+
+    return config
+
+
+class MetricTracker:
+    def __init__(self, *keys, writer=None):
+        self.writer = writer
+        self._data = pd.DataFrame(index=keys, columns=['total', 'counts', 'average'])
+        self.reset()
+
+    def reset(self):
+        for col in self._data.columns:
+            self._data[col].values[:] = 0
+
+    def update(self, key, value, n=1):
+        if self.writer is not None:
+            self.writer.add_scalar(key, value)
+        self._data.total[key] += value * n
+        self._data.counts[key] += n
+        self._data.average[key] = self._data.total[key] / self._data.counts[key]
+
+    def avg(self, key):
+        return self._data.average[key]
+
+    def result(self):
+        return dict(self._data.average)
+
+
+class TensorboardWriter():
+    def __init__(self, log_dir, enabled):
+        self.writer = None
+        self.selected_module = ""
+
+        if enabled:
+            log_dir = str(log_dir)
+
+            # Retrieve vizualization writer.
+            succeeded = False
+            for module in ["torch.utils.tensorboard", "tensorboardX"]:
+                try:
+                    self.writer = importlib.import_module(module).SummaryWriter(log_dir)
+                    succeeded = True
+                    break
+                except ImportError:
+                    succeeded = False
+                self.selected_module = module
+
+            if not succeeded:
+                message = "Warning: visualization (Tensorboard) is configured to use, but currently not installed on " \
+                    "this machine. Please install TensorboardX with 'pip install tensorboardx', upgrade PyTorch to " \
+                    "version >= 1.1 to use 'torch.utils.tensorboard' or turn off the option in the 'config.json' file."
+                print(message)
+
+        self.step = 0
+        self.mode = ''
+
+        self.tb_writer_ftns = {
+            'add_scalar', 'add_scalars', 'add_image', 'add_images', 'add_audio',
+            'add_text', 'add_histogram', 'add_pr_curve', 'add_embedding'
+        }
+        self.tag_mode_exceptions = {'add_histogram', 'add_embedding'}
+        self.timer = datetime.now()
+
+    def set_step(self, step, mode='train'):
+        self.mode = mode
+        self.step = step
+        if step == 0:
+            self.timer = datetime.now()
+        else:
+            duration = datetime.now() - self.timer
+            self.add_scalar('steps_per_sec', 1 / duration.total_seconds())
+            self.timer = datetime.now()
+
+    def __getattr__(self, name):
+        """
+        If visualization is configured to use:
+            return add_data() methods of tensorboard with additional information (step, tag) added.
+        Otherwise:
+            return a blank function handle that does nothing
+        """
+        if name in self.tb_writer_ftns:
+            add_data = getattr(self.writer, name, None)
+
+            def wrapper(tag, data, *args, **kwargs):
+                if add_data is not None:
+                    # add mode(train/valid) tag
+                    if name not in self.tag_mode_exceptions:
+                        tag = '{}/{}'.format(tag, self.mode)
+                    if name == 'add_embedding':
+                        add_data(tag=tag, mat=data, global_step=self.step, *args, **kwargs)
+                    else:
+                        add_data(tag, data, self.step, *args, **kwargs)
+            return wrapper
+        else:
+            # default action for returning methods defined in this class, set_step() for instance.
+            try:
+                attr = object.__getattr__(name)
+            except AttributeError:
+                raise AttributeError("type object '{}' has no attribute '{}'".format(self.selected_module, name))
+            return attr


### PR DESCRIPTION
复现论文: [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale](https://arxiv.org/abs/2010.11929)
参考Repo:
- [ViT-pytorch](https://github.com/jeonsworld/ViT-pytorch)
- [vision-transformer-pytorch](https://github.com/asyml/vision-transformer-pytorch)

预期实现以下内容:
- [x] 使用oneflow复现vision transformer模型
- [ ] 重新基于jax保存为torch并转换为oneflow权重的代码
- [ ] 首先实现`ViT-B_16`模型，然后再拓展到其他模型

第一阶段实现目标:
- [x] 修改pytorch版本的vit模型，修改权重加载方式，并验证torch model的准确性
- [ ] 解决超参和权重都与torch版本一致的情况下，无法收敛的问题，并在ImageNet上重新fine-tune 
- [ ] 加载别人训练好的权重，实现基本的推理脚本，在ImageNet的`val`上验证准确率
- [ ] 添加权重脚本，添加README

目前代码完成情况:
- vit-oneflow的完整训练代码，在`vit_oneflow_old`下直接执行`bash train.sh`即可运行，但是需要加载权重，有需要的我可以传，但是无法收敛
- 基于新版的vit搬运模型ing，先实现eval脚本