### PR TITLE
nn_graph label smoothing

### DIFF
--- a/resnet50/check/check_labelsmoothing.py
+++ b/resnet50/check/check_labelsmoothing.py
@@ -1,0 +1,409 @@
+import oneflow as flow
+import argparse
+import numpy as np
+import os
+import time
+from tqdm import tqdm
+from oneflow.nn.module import Module
+
+import sys
+sys.path.append(".")
+from models.resnet50 import resnet50
+from utils.ofrecord_data_utils import OFRecordDataLoader
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser("flags for train resnet50")
+    parser.add_argument(
+        "--save_checkpoint_path",
+        type=str,
+        default="./checkpoints",
+        help="save checkpoint root dir",
+    )
+    parser.add_argument(
+        "--load_checkpoint", type=str, default="", help="load checkpoint"
+    )
+    parser.add_argument(
+        "--ofrecord_path", type=str, default="./ofrecord/", help="dataset path"
+    )
+    # training hyper-parameters
+    parser.add_argument(
+        "--learning_rate", type=float, default=0.001, help="learning rate"
+    )
+    parser.add_argument("--mom", type=float, default=0.9, help="momentum")
+    parser.add_argument("--epochs", type=int, default=20, help="training epochs")
+    parser.add_argument(
+        "--train_batch_size", type=int, default=32, help="train batch size"
+    )
+    parser.add_argument("--val_batch_size", type=int, default=4, help="val batch size")
+    parser.add_argument("--results", type=str, default="./results", help="tensorboard file path")
+    parser.add_argument("--tag", type=str, default="default", help="tag of experiment")
+    parser.add_argument(
+        "--print_interval", type=int, default=10, help="print info frequency"
+    )
+    return parser.parse_args()
+
+class LabelSmoothLoss(Module):
+    def __init__(self, num_classes=-1, smooth_rate=0.0) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.smooth_rate = smooth_rate
+    
+    def forward(self, input, label):
+        onehot_label = flow.F.one_hot(label, num_classes= self.num_classes, 
+                                                on_value=1-self.smooth_rate, 
+                                                off_value=self.smooth_rate/(self.num_classes-1))
+        log_prob = input.softmax(dim=-1).log()
+        onehot_label = onehot_label.to(log_prob.dtype).to("cuda")
+        loss = flow.mul(log_prob * -1, onehot_label).sum(dim=-1).mean()
+        return loss
+
+def setup(args):
+    train_data_loader = OFRecordDataLoader(
+        ofrecord_root=args.ofrecord_path,
+        mode="train",
+        dataset_size=9469,
+        batch_size=args.train_batch_size,
+    )
+
+    val_data_loader = OFRecordDataLoader(
+        ofrecord_root=args.ofrecord_path,
+        mode="val",
+        dataset_size=3925,
+        batch_size=args.val_batch_size,
+    )
+
+    criterion = flow.nn.CrossEntropyLoss()
+
+    # model setup
+    eager_model = resnet50()
+    graph_model = resnet50()
+    graph_model.load_state_dict(eager_model.state_dict())
+
+    eager_model.to("cuda")
+    graph_model.to("cuda")
+    # optimizer setup
+    eager_optimizer = flow.optim.SGD(
+        eager_model.parameters(), lr=args.learning_rate, momentum=args.mom
+    )
+    graph_optimizer = flow.optim.SGD(
+        graph_model.parameters(), lr=args.learning_rate, momentum=args.mom
+    )
+
+    # criterion setup
+    criterion = flow.nn.CrossEntropyLoss()
+    criterion = criterion.to("cuda")
+
+    ls_loss = LabelSmoothLoss(num_classes=1000, smooth_rate=0.1)
+    ls_loss = ls_loss.to("cuda")
+
+    class ModelTrainGraph1(flow.nn.Graph):
+        def __init__(self):
+            super().__init__()
+            self.graph_model = graph_model
+            self.criterion = criterion
+            self.add_optimizer(graph_optimizer)
+
+        def build(self, image, label):
+            logits = self.graph_model(image)
+            loss = self.criterion(logits, label)
+            loss.backward()
+            return loss
+
+    class ModelTrainGraph2(flow.nn.Graph):
+        def __init__(self):
+            super().__init__()
+            self.graph_model = eager_model
+            self.criterion = ls_loss
+            self.add_optimizer(eager_optimizer)
+
+        def build(self, image, label):
+            logits = self.graph_model(image)
+            loss = self.criterion(logits, label)
+            loss.backward()
+            return loss
+
+    class ModelEvalGraph1(flow.nn.Graph):
+        def __init__(self):
+            super().__init__()
+            self.graph_model = graph_model
+
+        def build(self, image):
+            with flow.no_grad():
+                logits = self.graph_model(image)
+                predictions = logits.softmax()
+            return predictions
+
+    class ModelEvalGraph2(flow.nn.Graph):
+        def __init__(self):
+            super().__init__()
+            self.graph_model = eager_model
+
+        def build(self, image):
+            with flow.no_grad():
+                logits = self.graph_model(image)
+                predictions = logits.softmax()
+            return predictions
+
+    model_train_graph1 = ModelTrainGraph1()
+    model_eval_graph1 = ModelEvalGraph1()
+
+    model_train_graph2 = ModelTrainGraph2()
+    model_eval_graph2 = ModelEvalGraph2()
+
+    dic = { "train_dataloader": train_data_loader,
+            "val_dataloader": val_data_loader,
+            "eager": [eager_model, model_train_graph2, model_eval_graph2],
+            "graph": [graph_model, model_train_graph1, model_eval_graph1]
+    }
+
+    return dic
+
+class Trainer(object):
+    def __init__(self, args):
+        super().__init__()
+        self.graph_losses = []
+        self.eager_losses = []
+
+        self.graph_acc = []
+        self.eager_acc = []
+
+        self.graph_train_step_time_list = []
+        self.eager_train_step_time_list = []
+
+        self.graph_train_epoch_time_list = []
+        self.eager_train_epoch_time_list = []
+
+        self.graph_eval_epoch_time_list = []
+        self.eager_eval_epoch_time_list = []
+
+        self.eager_graph_model_diff_list = []
+
+        self.graph_train_total_time = 0.0
+        self.eager_train_total_time = 0.0
+
+        self.graph_eval_total_time = 0.0
+        self.eager_val_total_time = 0.0
+
+        self.args = args
+
+    def compare_eager_graph(self, compare_dic):
+
+        train_data_loader = compare_dic["train_dataloader"]
+        val_data_loader = compare_dic["val_dataloader"]
+        eager_model, model_train_graph2, model_eval_graph2 = compare_dic["eager"]
+        graph_model, model_train_graph1, model_eval_graph1 = compare_dic["graph"]
+
+
+        all_samples = len(val_data_loader) * self.args.val_batch_size
+        print_interval = self.args.print_interval
+
+        print("start training")
+        for epoch in range(self.args.epochs):
+            # train        
+            eager_model.train()
+            graph_model.train()
+            start_training_time = time.time()
+            total_graph_iter_time, total_eager_iter_time = 0, 0
+
+            for b in range(len(train_data_loader)):
+                image, label = train_data_loader()
+                image = image.to("cuda")
+                label = label.to("cuda")
+
+                # oneflow graph train
+                graph_iter_start_time = time.time()
+                graph_loss = model_train_graph1(image, label)
+                graph_loss.numpy() # for synchronize CPU and GPU, get accurate running time
+                graph_iter_end_time = time.time()
+
+                # oneflow eager train
+                eager_iter_start_time = time.time()
+                eager_loss = model_train_graph2(image, label)
+                eager_loss.numpy()  # for synchronize CPU and GPU, get accurate running time
+                eager_iter_end_time = time.time()
+
+                model_param_diff = compare_model_params(eager_model, model_train_graph1)
+                self.eager_graph_model_diff_list.append(model_param_diff)
+
+                # get time
+                graph_iter_time = graph_iter_end_time - graph_iter_start_time
+                eager_iter_time = eager_iter_end_time - eager_iter_start_time
+                total_graph_iter_time += graph_iter_time
+                total_eager_iter_time += eager_iter_time
+
+                if b % print_interval == 0:
+                    gl, el = graph_loss.numpy(), eager_loss.numpy()    
+                    print(
+                        "epoch {} train iter {} ; graph loss {} eager loss {};  graph train time: {}  eager train time {}".format(
+                            epoch, b, gl, el, graph_iter_time, eager_iter_time
+                        )
+                    )
+                    self.graph_losses.append(gl)
+                    self.graph_train_step_time_list.append(graph_iter_time)
+                    self.eager_losses.append(el)
+                    self.eager_train_step_time_list.append(eager_iter_time)
+
+
+            end_training_time = time.time()
+            self.graph_train_epoch_time_list.append(end_training_time - start_training_time- total_eager_iter_time)
+            self.eager_train_epoch_time_list.append(end_training_time - start_training_time- total_graph_iter_time)
+            print("epoch %d train done, start validation" % epoch)
+
+            # validate
+            eager_model.eval()
+            graph_model.eval()
+            graph_correct, eager_correct = 0.0, 0.0
+            eval_start_time = time.time()
+            total_graph_infer_time, total_eager_infer_time = 0, 0
+            for b in tqdm(range(len(val_data_loader))):
+                image, label = val_data_loader()
+                image = image.to("cuda")
+
+                # graph val
+                graph_infer_time = time.time()
+                predictions = model_eval_graph1(image)
+                graph_preds = predictions.numpy()
+                graph_clsidxs = np.argmax(graph_preds, axis=1)
+                total_graph_infer_time += time.time() - graph_infer_time
+
+                # eager val
+                eager_infer_time = time.time()
+                predictions = model_eval_graph2(image)
+                eager_preds = predictions.numpy()
+                eager_clsidxs = np.argmax(eager_preds, axis=1)
+                total_eager_infer_time += time.time() - eager_infer_time
+
+                label_nd = label.numpy()
+                for i in range(self.args.val_batch_size):
+                    if graph_clsidxs[i] == label_nd[i]:
+                        graph_correct += 1
+                    if eager_clsidxs[i] == label_nd[i]:
+                        eager_correct += 1
+            eval_end_time = time.time()
+            self.graph_eval_epoch_time_list.append(eval_end_time - eval_start_time - total_eager_infer_time)
+            self.eager_eval_epoch_time_list.append(eval_end_time - eval_start_time - total_graph_infer_time)
+            graph_top1_acc, eager_top1_acc = graph_correct / all_samples, eager_correct / all_samples
+            self.graph_acc.append(graph_top1_acc)
+            self.eager_acc.append(eager_top1_acc)
+            print("epoch %d, graph top1 val acc: %f, eager top1 val acc: %f" % (epoch, graph_top1_acc, eager_top1_acc))
+
+
+    def save_report(self,):
+        print("***** Save Report *****")
+        # folder setup
+        report_path = os.path.join(self.args.results)
+        os.makedirs(report_path, exist_ok=True)
+        
+        # calculate absolute loss difference
+        abs_loss_diff = abs(np.array(self.eager_losses) - np.array(self.graph_losses))
+
+        # calculate losses linear correlation
+        loss_corr = calc_corr(self.eager_losses, self.graph_losses)
+
+        # calculate accuracy linear correlation
+        acc_corr = calc_corr(self.eager_acc, self.graph_acc)
+
+        # training time compare
+        train_time_compare = time_compare(self.graph_train_epoch_time_list, self.eager_train_epoch_time_list)
+
+        # validate time compare
+        val_time_compare = time_compare(self.graph_eval_epoch_time_list, self.eager_eval_epoch_time_list)
+
+        # eager graph model diff compare
+        model_diff_compare = np.array(self.eager_graph_model_diff_list)
+
+        # save report
+        save_path = os.path.join(report_path, 'check_report.txt')
+        writer = open(save_path, "w")
+        writer.write("Check Report\n")
+        writer.write("Model: Resnet50\n")
+        writer.write("Check Results Between Eager Model and Graph Model\n")
+        writer.write("=================================================\n")
+        writer.write("Loss Correlation: %.4f\n\n" % loss_corr)
+        writer.write("Max Loss Difference: %.4f\n" % abs_loss_diff.max())
+        writer.write("Min Loss Difference: %.4f\n" % abs_loss_diff.min())
+        writer.write("Loss Difference Range: (%.4f, %.4f)\n\n" % (abs_loss_diff.min(), abs_loss_diff.max()))
+        writer.write("Model Param Difference Range: (%.4f, %.4f)\n\n" % (model_diff_compare.min(), model_diff_compare.max()))
+        writer.write("Accuracy Correlation: %.4f\n\n" % acc_corr)
+        writer.write("Train Time Compare: %.4f (Eager) : %.4f (Graph)\n\n" % (1.0, train_time_compare))
+        writer.write("Val Time Compare: %.4f (Eager) : %.4f (Graph)" % (1.0, val_time_compare))
+        writer.close()
+        print("Report saved to: ", save_path)
+
+    def save_result(self,):
+        # create folder
+        training_results_path = os.path.join(self.args.results, self.args.tag)
+        os.makedirs(training_results_path, exist_ok=True)
+        print("***** Save Results *****")
+        save_results(self.graph_losses, os.path.join(training_results_path, 'graph_losses.txt'))
+        save_results(self.eager_losses, os.path.join(training_results_path, 'eager_losses.txt'))
+        
+        save_results(self.graph_acc, os.path.join(training_results_path, 'graph_acc.txt'))
+        save_results(self.eager_acc, os.path.join(training_results_path, 'eager_acc.txt'))
+        
+        save_results(self.graph_train_step_time_list, os.path.join(training_results_path, 'graph_train_step_time_list.txt'))
+        save_results(self.eager_train_step_time_list, os.path.join(training_results_path, 'eager_train_step_time_list.txt'))
+        
+        save_results(self.graph_train_epoch_time_list, os.path.join(training_results_path, 'graph_train_epoch_time_list.txt'))
+        save_results(self.eager_train_epoch_time_list, os.path.join(training_results_path, 'eager_train_epoch_time_list.txt'))
+        
+        save_results(self.graph_eval_epoch_time_list, os.path.join(training_results_path, 'graph_eval_epoch_time_list.txt'))
+        save_results(self.eager_eval_epoch_time_list, os.path.join(training_results_path, 'eager_eval_epoch_time_list.txt'))
+        
+        save_results(self.eager_graph_model_diff_list, os.path.join(training_results_path, 'eager_graph_model_diff_list.txt'))
+
+        print("Results saved to: ", training_results_path)
+
+def compare_model_params(eager_model, graph_model):
+    num_params = len(eager_model.state_dict().keys())
+    sum_diff = 0.0
+    for key in eager_model.state_dict():
+        mean_single_diff = (eager_model.state_dict()[key] - graph_model.graph_model.state_dict()[key]._origin).abs().mean()
+        sum_diff += mean_single_diff
+    mean_diff = float(sum_diff.numpy() / num_params)
+    return mean_diff
+
+def save_results(training_info, file_path):
+    writer = open(file_path, "w")
+    for info in training_info:
+        writer.write("%f\n" % info)
+    writer.close()
+
+# report helpers
+def square(lst):
+    res = list(map(lambda x: x ** 2, lst))
+    return res
+
+# calculate correlation
+def calc_corr(a, b):
+    E_a = np.mean(a)
+    E_b = np.mean(b)
+    E_ab = np.mean(list(map(lambda x: x[0] * x[1], zip(a, b))))
+
+    cov_ab = E_ab - E_a * E_b
+
+    D_a = np.mean(square(a)) - E_a ** 2
+    D_b = np.mean(square(b)) - E_b ** 2
+
+    σ_a = np.sqrt(D_a)
+    σ_b = np.sqrt(D_b)
+
+    corr_factor = cov_ab / (σ_a * σ_b)
+    return corr_factor
+
+def time_compare(a, b):
+    return np.divide(a, b).mean()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    trainer = Trainer(args)
+    compare_dic = setup(args)
+    print("init done")
+    trainer.compare_eager_graph(compare_dic)
+    del compare_dic
+
+    # save results
+    trainer.save_result()
+    trainer.save_report()

--- a/resnet50/graph/train_labelsmooth.py
+++ b/resnet50/graph/train_labelsmooth.py
@@ -1,0 +1,194 @@
+import oneflow as flow
+import argparse
+import numpy as np
+import os
+import time
+from oneflow.nn.module import Module
+import sys
+
+sys.path.append(".")
+from models.resnet50 import resnet50
+from utils.ofrecord_data_utils import OFRecordDataLoader
+
+def _parse_args():
+    parser = argparse.ArgumentParser("flags for train resnet50")
+    parser.add_argument(
+        "--save_checkpoint_path",
+        type=str,
+        default="./checkpoints",
+        help="save checkpoint root dir",
+    )
+    parser.add_argument(
+        "--load_checkpoint", type=str, default="", help="load checkpoint"
+    )
+    parser.add_argument(
+        "--ofrecord_path", type=str, default="./ofrecord", help="dataset path"
+    )
+    # training hyper-parameters
+    parser.add_argument(
+        "--learning_rate", type=float, default=0.001, help="learning rate"
+    )
+    parser.add_argument("--mom", type=float, default=0.9, help="momentum")
+    parser.add_argument("--epochs", type=int, default=100, help="training epochs")
+    parser.add_argument(
+        "--train_batch_size", type=int, default=32, help="train batch size"
+    )
+    parser.add_argument("--val_batch_size", type=int, default=32, help="val batch size")
+
+    parser.add_argument("--num_classes", type=int, default=1000, help="number of class")
+    parser.add_argument("--label_smooth_rate", type=float, default=0.0, help="val batch size")
+
+
+    return parser.parse_args()
+
+class LabelSmoothLoss(Module):
+    def __init__(self, num_classes=-1, smooth_rate=0.0) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.smooth_rate = smooth_rate
+    
+    def forward(self, input, label):
+        onehot_label = flow.F.one_hot(label, num_classes= self.num_classes, 
+                                                on_value=1-self.smooth_rate, 
+                                                off_value=self.smooth_rate/(self.num_classes-1))
+        log_prob = input.softmax(dim=-1).log()
+        onehot_label = onehot_label.to(log_prob.dtype).to("cuda")
+        loss = flow.mul(log_prob * -1, onehot_label).sum(dim=-1).mean()
+        return loss
+
+def main(args):
+    train_data_loader = OFRecordDataLoader(
+        ofrecord_root=args.ofrecord_path,
+        mode="train",
+        dataset_size=9469,
+        batch_size=args.train_batch_size,
+    )
+
+    val_data_loader = OFRecordDataLoader(
+        ofrecord_root=args.ofrecord_path,
+        mode="val",
+        dataset_size=3925,
+        batch_size=args.val_batch_size,
+    )
+
+    # oneflow init
+    start_t = time.time()
+    resnet50_module = resnet50()
+    if args.load_checkpoint != "":
+        print("load_checkpoint >>>>>>>>> ", args.load_checkpoint)
+        resnet50_module.load_state_dict(flow.load(args.load_checkpoint))
+
+    end_t = time.time()
+    print("init time : {}".format(end_t - start_t))
+
+    # of_cross_entropy = flow.nn.CrossEntropyLoss()
+    of_loss = LabelSmoothLoss(num_classes=args.num_classes, smooth_rate=args.label_smooth_rate)
+
+    resnet50_module.to("cuda")
+    of_loss.to("cuda")
+
+    of_sgd = flow.optim.SGD(
+        resnet50_module.parameters(), lr=args.learning_rate, momentum=args.mom
+    )
+
+    class Resnet50Graph(flow.nn.Graph):
+        def __init__(self):
+            super().__init__()
+            self.resnet50 = resnet50_module
+            self.of_loss = of_loss
+            # self.add_optimizer("sgd", of_sgd)
+            self.add_optimizer(of_sgd)
+            self.train_data_loader = train_data_loader
+        
+        def build(self):
+            image, label = self.train_data_loader()
+            image = image.to("cuda")
+            logits = self.resnet50(image)
+            loss = self.of_loss(logits, label)
+            loss.backward()
+            return loss
+
+    resnet50_graph = Resnet50Graph()
+
+    class Resnet50EvalGraph(flow.nn.Graph):
+        def __init__(self):
+            super().__init__()
+            self.resnet50 = resnet50_module
+            self.val_data_loader = val_data_loader
+        
+        def build(self,):
+            image, label = self.val_data_loader()
+            image = image.to("cuda")
+            label = label.to("cuda")
+            with flow.no_grad():
+                logits = self.resnet50(image)
+                predictions = logits.softmax()
+            return predictions, label
+
+    resnet50_eval_graph = Resnet50EvalGraph()
+
+    of_losses, of_accuracy = [], []
+    all_samples = len(val_data_loader) * args.val_batch_size
+    print_interval = 100
+
+
+    for epoch in range(args.epochs):
+        resnet50_module.train()
+
+        for b in range(len(train_data_loader)):
+            # oneflow graph train
+            start_t = time.time()
+
+            loss = resnet50_graph()
+
+            end_t = time.time()
+            if b % print_interval == 0:
+                l = loss.numpy()
+                of_losses.append(l)
+                print(
+                    "epoch {} train iter {} oneflow loss {}, train time : {}".format(
+                        epoch, b, l, end_t - start_t
+                    )
+                )
+
+        print("epoch %d train done, start validation" % epoch)
+
+        resnet50_module.eval()
+        correct_of = 0.0
+        for b in range(len(val_data_loader)):
+            start_t = time.time()
+            predictions, label = resnet50_eval_graph()
+            of_predictions = predictions.numpy()
+            clsidxs = np.argmax(of_predictions, axis=1)
+
+            label_nd = label.numpy()
+            for i in range(args.val_batch_size):
+                if clsidxs[i] == label_nd[i]:
+                    correct_of += 1
+            end_t = time.time()
+
+        top1 = correct_of / all_samples
+        of_accuracy.append(top1)
+        print("epoch %d, oneflow top1 val acc: %f" % (epoch, top1))
+
+        flow.save(
+            resnet50_module.state_dict(),
+            os.path.join(
+                args.save_checkpoint_path,
+                "epoch_%d_val_acc_%f" % (epoch, correct_of / all_samples),
+            ),
+        )
+
+    writer = open("graph_of_losses.txt", "w")
+    for o in of_losses:
+        writer.write("%f\n" % o)
+    writer.close()
+
+    writer = open("graph/accuracy.txt", "w")
+    for o in of_accuracy:
+        writer.write("%f\n" % o)
+    writer.close()
+
+if __name__ == "__main__":
+    args = _parse_args()
+    main(args)

--- a/resnet50/graph/train_labelsmooth.sh
+++ b/resnet50/graph/train_labelsmooth.sh
@@ -1,0 +1,33 @@
+set -aux
+
+OFRECORD_PATH="ofrecord"
+if [ ! -d "$OFRECORD_PATH" ]; then
+    wget https://oneflow-public.oss-cn-beijing.aliyuncs.com/datasets/imagenette_ofrecord.tar.gz
+    tar zxf imagenette_ofrecord.tar.gz
+fi
+
+CHECKPOINT_PATH="checkpoints"
+if [ ! -d "$CHECKPOINT_PATH" ]; then
+    mkdir $CHECKPOINT_PATH
+fi
+
+LEARNING_RATE=0.001
+MOM=0.9
+EPOCH=20
+TRAIN_BATCH_SIZE=16
+VAL_BATCH_SIZE=16
+NUM_CLASSES=1000
+LABEL_SMOOTH_RATE=0.1
+#LOAD_CHECKPOINT="path/to/your_pretrain_model" # LOAD PREVIOUS CHECKPOINT 
+
+python3 graph/train_labelsmooth.py \
+    --save_checkpoint_path $CHECKPOINT_PATH \
+    --ofrecord_path $OFRECORD_PATH \
+    --learning_rate $LEARNING_RATE \
+    --mom $MOM \
+    --epochs $EPOCH \
+    --train_batch_size $TRAIN_BATCH_SIZE \
+    --val_batch_size $VAL_BATCH_SIZE \
+    --num_classes $NUM_CLASSES \
+    --label_smooth_rate $LABEL_SMOOTH_RATE
+    #--load_checkpoint $LOAD_CHECKPOINT

--- a/resnet50/utils/test_labelsmoothloss.py
+++ b/resnet50/utils/test_labelsmoothloss.py
@@ -1,0 +1,60 @@
+import oneflow as flow
+from oneflow.nn.module import Module
+import numpy as np
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class LabelSmoothingLoss(nn.Module):
+    def __init__(self, classes, smoothing=0.0, dim=-1):
+        super(LabelSmoothingLoss, self).__init__()
+        self.confidence = 1.0 - smoothing
+        self.smoothing = smoothing
+        self.cls = classes
+        self.dim = dim
+
+    def forward(self, pred, target):
+        pred = pred.log_softmax(dim=self.dim)
+        with torch.no_grad():
+            # true_dist = pred.data.clone()
+            true_dist = torch.zeros_like(pred)
+            true_dist.fill_(self.smoothing / (self.cls - 1))
+            true_dist.scatter_(1, target.data.unsqueeze(1), self.confidence)
+        return torch.mean(torch.sum(-true_dist * pred, dim=self.dim))
+
+
+class LabelSmooth(Module):
+    def __init__(self, num_classes=-1, smooth_rate=0.0) -> None:
+        super().__init__()
+        self.num_classes = num_classes
+        self.smooth_rate = smooth_rate
+    
+    def forward(self, input, label):
+        _label = flow.Tensor(label, dtype=flow.int32)
+        onehot_label = flow.nn.functional.one_hot(_label, num_classes= self.num_classes, 
+                                                on_value=1-self.smooth_rate, 
+                                                off_value=self.smooth_rate/(self.num_classes-1))
+        log_prob = input.softmax(dim=-1).log()
+        onehot_label = onehot_label.to(log_prob)
+        loss = flow.mul(log_prob * -1, onehot_label).sum(dim=-1).mean()
+        return loss
+
+if __name__ == "__main__":
+    for i in range(10):
+        np_input = np.random.randn(3,3).astype(np.float32)
+        np_label = np.array([0, 1, 2]).astype(np.int64)
+
+        #oneflow
+        flow_input = flow.Tensor(np_input.copy(), dtype=flow.float32)
+        flow_label = flow.Tensor(np_label.copy(), dtype=flow.int64)
+        loss = LabelSmooth(num_classes=3, smooth_rate=0.1)
+        flow_loss = loss(flow_input, flow_label)
+
+        #pytorch
+        torch_input = torch.from_numpy(np_input.copy()).to(torch.float32)
+        torch_label = torch.from_numpy(np_label.copy()).to(torch.int64)
+        loss = LabelSmoothingLoss(classes=3, smoothing=0.1)
+        torch_loss = loss(torch_input, torch_label)
+
+        print(f"abs diff: {flow_loss.numpy() - torch_loss.numpy()}, flow labelsmooth loss: {flow_loss}, torch labelsmooth loss:{torch_loss}")


### PR DESCRIPTION
### 这个pr要解决的：
- [x] 在nn_graph中加入label smooth的trick进行训练，训练结果见下图
- [x] 和pytorch实现的label smooth进行对齐

pytorch的实现源自于[此处](https://github.com/pytorch/pytorch/issues/7455#issuecomment-513062631)
运行python utils/test_labelsmooth.py即可得到结果，误差最大值的量级在e-7, 几乎一样

```
abs diff: 1.1920928955078125e-07, flow labelsmooth loss: 1.3462207317352295, torch labelsmooth loss:1.34622061252594
abs diff: 1.1920928955078125e-07, flow labelsmooth loss: 1.5114572048187256, torch labelsmooth loss:1.511457085609436
abs diff: 0.0, flow labelsmooth loss: 1.6171989440917969, torch labelsmooth loss:1.6171989440917969
abs diff: 0.0, flow labelsmooth loss: 0.6735591292381287, torch labelsmooth loss:0.6735591292381287
abs diff: 0.0, flow labelsmooth loss: 1.9999173879623413, torch labelsmooth loss:1.9999173879623413
abs diff: 1.1920928955078125e-07, flow labelsmooth loss: 1.3488662242889404, torch labelsmooth loss:1.3488661050796509
abs diff: 0.0, flow labelsmooth loss: 1.5050686597824097, torch labelsmooth loss:1.5050686597824097
abs diff: 1.1920928955078125e-07, flow labelsmooth loss: 1.449904203414917, torch labelsmooth loss:1.4499040842056274
abs diff: 0.0, flow labelsmooth loss: 1.8043279647827148, torch labelsmooth loss:1.8043279647827148
abs diff: 5.960464477539063e-08, flow labelsmooth loss: 0.7393254041671753, torch labelsmooth loss:0.7393253445625305
```

#### 添加loss后结果比较
共用超参
- 数据集：imagenette
- lr: 0.001
- batch_size: 32
- optimizer: sgd
- momentum: 0.9
- epochs: 20

不同超参：

- ce_loss: 采用cross_entropy loss
- ls_loss: 采用label_smooth loss
在nn_graph中使用ce_loss(cross_entropy loss)和ls_loss(label_smooth loss)对比结果：
#### val acc比较
![compare_ce_ls_acc](https://user-images.githubusercontent.com/13843079/129874196-afa8d618-2dcd-4b86-8e7b-953c263a7b62.png)
#### loss数值比较
![compare_ce_ls_loss](https://user-images.githubusercontent.com/13843079/129874243-58b2111c-38bb-4705-88eb-163749335002.png)


由于数据集比较小，结果可能存在偶然性，但是根据对比得出label smooth可以正常训练，目前看来没有什么问题