### PR TITLE
Wide ResNet OneFlow

### DIFF
--- a/wide_resnet/eval/torch_loader.py
+++ b/wide_resnet/eval/torch_loader.py
@@ -1,0 +1,99 @@
+import os
+from torch.utils.data import DataLoader
+from torchvision.datasets import CIFAR10, CIFAR100, ImageFolder
+from torchvision.transforms import transforms
+
+
+__all__ = ['CIFAR10DataLoader', 'ImageNetDataLoader', 'CIFAR100DataLoader']
+
+
+class CIFAR10DataLoader(DataLoader):
+    def __init__(self, data_dir, split='train', image_size=224, batch_size=16, num_workers=8):
+        if split == 'train':
+            train = True
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+        else:
+            train = False
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+
+        self.dataset = CIFAR10(root=data_dir, train=train, transform=transform, download=True)
+
+        super(CIFAR10DataLoader, self).__init__(
+            dataset=self.dataset,
+            batch_size=batch_size,
+            shuffle=False if not train else True,
+            num_workers=num_workers)
+
+
+class CIFAR100DataLoader(DataLoader):
+    def __init__(self, data_dir, split='train', image_size=224, batch_size=16, num_workers=8):
+        if split == 'train':
+            train = True
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+        else:
+            train = False
+            transform = transforms.Compose([
+                transforms.Resize(image_size),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+
+        self.dataset = CIFAR100(root=data_dir, train=train, transform=transform, download=True)
+
+        super(CIFAR100DataLoader, self).__init__(
+            dataset=self.dataset,
+            batch_size=batch_size,
+            shuffle=False if not train else True,
+            num_workers=num_workers)
+
+
+class ImageNetDataLoader(DataLoader):
+    def __init__(self, data_dir, split='train', image_size=224, batch_size=16, num_workers=8):
+
+        if split == 'train':
+            transform = transforms.Compose([
+                transforms.Resize((image_size, image_size)),
+                transforms.RandomHorizontalFlip(),
+                transforms.ToTensor(),
+                transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+            ])
+        else:
+            transform = transforms.Compose([
+                transforms.Resize((image_size, image_size)),
+                transforms.ToTensor(),
+                # transforms.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5])
+                transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
+            ])
+
+        self.dataset = ImageFolder(root=os.path.join(data_dir, split), transform=transform)
+        super(ImageNetDataLoader, self).__init__(
+            dataset=self.dataset,
+            batch_size=batch_size,
+            shuffle=True if split == 'train' else False,
+            num_workers=num_workers)
+
+
+if __name__ == '__main__':
+    data_loader = ImageNetDataLoader(
+        data_dir='/data/imagenet/extract',
+        split='val',
+        image_size=384,
+        batch_size=16,
+        num_workers=8)
+
+    for images, targets in data_loader:
+        print(targets)

--- a/wide_resnet/eval/valid_flow.py
+++ b/wide_resnet/eval/valid_flow.py
@@ -105,5 +105,5 @@ def main(model, checkpoint_path):
 if __name__ == "__main__":
     wide_resnet50_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet50_2-95faca4d.pth"
     wide_resnet101_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet101_2-32ee1156.pth"
-    model = wide_resnet50_2()
-    main(model, wide_resnet50_2_weight_path)
+    model = wide_resnet101_2()
+    main(model, wide_resnet101_2_weight_path)

--- a/wide_resnet/eval/valid_flow.py
+++ b/wide_resnet/eval/valid_flow.py
@@ -2,11 +2,21 @@ import os
 import torch
 import oneflow as flow
 import numpy as np
-from torchvision.models import wide_resnet50_2, wide_resnet101_2
+from tqdm import tqdm
+from model.wide_resnet import wide_resnet50_2, wide_resnet101_2
 from torch_loader import *
 
-wide_resnet50_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet50_2-95faca4d.pth"
-wide_resnet101_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet101_2-32ee1156.pth"
+def setup_device(n_gpu_use):
+    n_gpu = torch.cuda.device_count()
+    if n_gpu_use > 0 and n_gpu == 0:
+        print("Warning: There\'s no GPU available on this machine, training will be performed on CPU.")
+        n_gpu_use = 0
+    if n_gpu_use > n_gpu:
+        print("Warning: The number of GPU\'s configured to use is {}, but only {} are available on this machine.".format(n_gpu_use, n_gpu))
+        n_gpu_use = n_gpu
+    device = torch.device('cuda:0' if n_gpu_use > 0 else 'cpu')
+    list_ids = list(range(n_gpu_use))
+    return device, list_ids
 
 def accuracy(output, target, topk=(1,)):
     """Computes the precision@k for the specified values of k"""""
@@ -23,36 +33,45 @@ def accuracy(output, target, topk=(1,)):
         res.append(correct_k / batch_size * 100.0)
     return res
 
-def main():
+def convert_checkpoint(state_dict):
+    new_parameters = dict()
+    for key, value in state_dict.items():
+        if "num_batches_tracked" not in key:
+            val = value.detach().cpu().numpy()
+            new_parameters[key] = val
+    return new_parameters
 
-    config = get_eval_config()
+# alexnet_module = alexnet()
+# alexnet_module.load_state_dict(new_parameters)
+# flow.save(alexnet_module.state_dict(), "alexnet_oneflow_model")
 
-    # create model
-    model = VisionTransformer(
-             image_size=(config.image_size, config.image_size),
-             patch_size=(config.patch_size, config.patch_size),
-             emb_dim=config.emb_dim,
-             mlp_dim=config.mlp_dim,
-             num_heads=config.num_heads,
-             num_layers=config.num_layers,
-             num_classes=config.num_classes,
-             attn_dropout_rate=config.attn_dropout_rate,
-             dropout_rate=config.dropout_rate)
+def main(model, checkpoint_path):
+
+
+    # device
+    device, device_ids = setup_device(1)
 
     # load checkpoint
-    if config.checkpoint_path:
-        state_dict = flow.load(config.checkpoint_path)
-        model.load_state_dict(state_dict)
-        print("Load pretrained weights from {}".format(config.checkpoint_path))
+    if checkpoint_path:
+        state_dict = torch.load(checkpoint_path)
+        new_parameters = dict()
+        for key, value in state_dict.items():
+            if "num_batches_tracked" not in key:
+                val = value.detach().cpu().numpy()
+                new_parameters[key] = val.astype(np.float32)
+        # flow_state_dict = convert_checkpoint(state_dict)
+        model.load_state_dict(new_parameters)
+        print("Load pretrained weights from {}".format(checkpoint_path))
 
+    # send model to device
+    model = model.to("cuda")
 
     # create dataloader
-    data_loader = eval("{}DataLoader".format(config.dataset))(
-                    # data_dir=os.path.join(config.data_dir, config.dataset),
-                    data_dir = config.data_dir,
-                    image_size=config.image_size,
-                    batch_size=config.batch_size,
-                    num_workers=config.num_workers,
+    data_loader = eval("{}DataLoader".format("ImageNet"))(
+                    data_dir="/data/imagenet/extract",
+                    image_size=224,
+                    batch_size=32,
+                    num_workers=8,
                     split='val')
     total_batch = len(data_loader)
 
@@ -60,21 +79,20 @@ def main():
     print("Starting evaluation")
     acc1s = []
     acc5s = []
-    model.to("cuda")
     model.eval()
     with flow.no_grad():
         pbar = tqdm(enumerate(data_loader), total=total_batch)
         for batch_idx, (data, target) in pbar:
             pbar.set_description("Batch {:05d}/{:05d}".format(batch_idx, total_batch))
-            # convert pytorch tensor to flow tensor
-            data = flow.tensor(data.numpy())
 
-            # load oneflow model and process data
-            data = data.to("cuda")
+            # data = data.to(device)
+            # target = target.to(device)
+            data = flow.tensor(data.numpy()).to("cuda")
+            target = target.to("cuda")
+            # target = flow.tensor(target.numpy()).to("cuda")
+
             pred_logits = model(data)
-
-            # convert to pytorch and evaluation
-            pred_logits = torch.tensor(pred_logits.numpy())
+            pred_logits = torch.tensor(pred_logits.numpy()).to(device)
             acc1, acc5 = accuracy(pred_logits, target, topk=(1, 5))
 
             acc1s.append(acc1.item())
@@ -82,4 +100,10 @@ def main():
 
             pbar.set_postfix(acc1=acc1.item(), acc5=acc5.item())
 
-    print("Evaluation of model {:s} on dataset {:s}, Acc@1: {:.4f}, Acc@5: {:.4f}".format(config.model_arch, config.dataset, np.mean(acc1s), np.mean(acc5s)))
+    print("Evaluation of model {:s} on dataset {:s}, Acc@1: {:.4f}, Acc@5: {:.4f}".format("wide_resnet50_2", "ImageNet", np.mean(acc1s), np.mean(acc5s)))
+
+if __name__ == "__main__":
+    wide_resnet50_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet50_2-95faca4d.pth"
+    wide_resnet101_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet101_2-32ee1156.pth"
+    model = wide_resnet50_2()
+    main(model, wide_resnet50_2_weight_path)

--- a/wide_resnet/eval/valid_flow.py
+++ b/wide_resnet/eval/valid_flow.py
@@ -1,0 +1,85 @@
+import os
+import torch
+import oneflow as flow
+import numpy as np
+from torchvision.models import wide_resnet50_2, wide_resnet101_2
+from torch_loader import *
+
+wide_resnet50_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet50_2-95faca4d.pth"
+wide_resnet101_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet101_2-32ee1156.pth"
+
+def accuracy(output, target, topk=(1,)):
+    """Computes the precision@k for the specified values of k"""""
+    maxk = max(topk)
+    batch_size = target.size(0)
+
+    _, pred = output.topk(maxk, 1, True, True)
+    pred = pred.t()
+    correct = pred.eq(target.view(1, -1).expand_as(pred))
+
+    res = []
+    for k in topk:
+        correct_k = correct[:k].contiguous().view(-1).float().sum(0)
+        res.append(correct_k / batch_size * 100.0)
+    return res
+
+def main():
+
+    config = get_eval_config()
+
+    # create model
+    model = VisionTransformer(
+             image_size=(config.image_size, config.image_size),
+             patch_size=(config.patch_size, config.patch_size),
+             emb_dim=config.emb_dim,
+             mlp_dim=config.mlp_dim,
+             num_heads=config.num_heads,
+             num_layers=config.num_layers,
+             num_classes=config.num_classes,
+             attn_dropout_rate=config.attn_dropout_rate,
+             dropout_rate=config.dropout_rate)
+
+    # load checkpoint
+    if config.checkpoint_path:
+        state_dict = flow.load(config.checkpoint_path)
+        model.load_state_dict(state_dict)
+        print("Load pretrained weights from {}".format(config.checkpoint_path))
+
+
+    # create dataloader
+    data_loader = eval("{}DataLoader".format(config.dataset))(
+                    # data_dir=os.path.join(config.data_dir, config.dataset),
+                    data_dir = config.data_dir,
+                    image_size=config.image_size,
+                    batch_size=config.batch_size,
+                    num_workers=config.num_workers,
+                    split='val')
+    total_batch = len(data_loader)
+
+    # starting evaluation
+    print("Starting evaluation")
+    acc1s = []
+    acc5s = []
+    model.to("cuda")
+    model.eval()
+    with flow.no_grad():
+        pbar = tqdm(enumerate(data_loader), total=total_batch)
+        for batch_idx, (data, target) in pbar:
+            pbar.set_description("Batch {:05d}/{:05d}".format(batch_idx, total_batch))
+            # convert pytorch tensor to flow tensor
+            data = flow.tensor(data.numpy())
+
+            # load oneflow model and process data
+            data = data.to("cuda")
+            pred_logits = model(data)
+
+            # convert to pytorch and evaluation
+            pred_logits = torch.tensor(pred_logits.numpy())
+            acc1, acc5 = accuracy(pred_logits, target, topk=(1, 5))
+
+            acc1s.append(acc1.item())
+            acc5s.append(acc5.item())
+
+            pbar.set_postfix(acc1=acc1.item(), acc5=acc5.item())
+
+    print("Evaluation of model {:s} on dataset {:s}, Acc@1: {:.4f}, Acc@5: {:.4f}".format(config.model_arch, config.dataset, np.mean(acc1s), np.mean(acc5s)))

--- a/wide_resnet/eval/valid_torch.py
+++ b/wide_resnet/eval/valid_torch.py
@@ -85,5 +85,5 @@ def main(model, checkpoint_path):
 if __name__ == "__main__":
     wide_resnet50_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet50_2-95faca4d.pth"
     wide_resnet101_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet101_2-32ee1156.pth"
-    model = wide_resnet50_2()
-    main(model, wide_resnet50_2_weight_path)
+    model = wide_resnet101_2()
+    main(model, wide_resnet101_2_weight_path)

--- a/wide_resnet/eval/valid_torch.py
+++ b/wide_resnet/eval/valid_torch.py
@@ -1,0 +1,89 @@
+import os
+import torch
+import oneflow as flow
+import numpy as np
+from tqdm import tqdm
+from torchvision.models import wide_resnet50_2, wide_resnet101_2
+from torch_loader import *
+
+def setup_device(n_gpu_use):
+    n_gpu = torch.cuda.device_count()
+    if n_gpu_use > 0 and n_gpu == 0:
+        print("Warning: There\'s no GPU available on this machine, training will be performed on CPU.")
+        n_gpu_use = 0
+    if n_gpu_use > n_gpu:
+        print("Warning: The number of GPU\'s configured to use is {}, but only {} are available on this machine.".format(n_gpu_use, n_gpu))
+        n_gpu_use = n_gpu
+    device = torch.device('cuda:0' if n_gpu_use > 0 else 'cpu')
+    list_ids = list(range(n_gpu_use))
+    return device, list_ids
+
+def accuracy(output, target, topk=(1,)):
+    """Computes the precision@k for the specified values of k"""""
+    maxk = max(topk)
+    batch_size = target.size(0)
+
+    _, pred = output.topk(maxk, 1, True, True)
+    pred = pred.t()
+    correct = pred.eq(target.view(1, -1).expand_as(pred))
+
+    res = []
+    for k in topk:
+        correct_k = correct[:k].contiguous().view(-1).float().sum(0)
+        res.append(correct_k / batch_size * 100.0)
+    return res
+
+def main(model, checkpoint_path):
+
+
+    # device
+    device, device_ids = setup_device(1)
+
+    # load checkpoint
+    if checkpoint_path:
+        state_dict = torch.load(checkpoint_path)
+        model.load_state_dict(state_dict)
+        print("Load pretrained weights from {}".format(checkpoint_path))
+
+    # send model to device
+    model = model.to(device)
+    if len(device_ids) > 1:
+        model = torch.nn.DataParallel(model, device_ids=device_ids)
+
+    # create dataloader
+    data_loader = eval("{}DataLoader".format("ImageNet"))(
+                    data_dir="/data/imagenet/extract",
+                    image_size=224,
+                    batch_size=32,
+                    num_workers=8,
+                    split='val')
+    total_batch = len(data_loader)
+
+    # starting evaluation
+    print("Starting evaluation")
+    acc1s = []
+    acc5s = []
+    model.eval()
+    with torch.no_grad():
+        pbar = tqdm(enumerate(data_loader), total=total_batch)
+        for batch_idx, (data, target) in pbar:
+            pbar.set_description("Batch {:05d}/{:05d}".format(batch_idx, total_batch))
+
+            data = data.to(device)
+            target = target.to(device)
+
+            pred_logits = model(data)
+            acc1, acc5 = accuracy(pred_logits, target, topk=(1, 5))
+
+            acc1s.append(acc1.item())
+            acc5s.append(acc5.item())
+
+            pbar.set_postfix(acc1=acc1.item(), acc5=acc5.item())
+
+    print("Evaluation of model {:s} on dataset {:s}, Acc@1: {:.4f}, Acc@5: {:.4f}".format("wide_resnet50_2", "ImageNet", np.mean(acc1s), np.mean(acc5s)))
+
+if __name__ == "__main__":
+    wide_resnet50_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet50_2-95faca4d.pth"
+    wide_resnet101_2_weight_path = "/data/rentianhe/code/new_models/models/wide_resnet/weight/torch/wide_resnet101_2-32ee1156.pth"
+    model = wide_resnet50_2()
+    main(model, wide_resnet50_2_weight_path)

--- a/wide_resnet/model/wide_resnet.py
+++ b/wide_resnet/model/wide_resnet.py
@@ -1,0 +1,323 @@
+  
+import oneflow as flow
+from oneflow import nn, Tensor
+
+from typing import Type, Any, Callable, Union, List, Optional
+
+
+__all__ = ["wide_resnet50_2", "wide_resnet101_2"]
+
+
+def conv3x3(
+    in_planes: int, out_planes: int, stride: int = 1, groups: int = 1, dilation: int = 1
+) -> nn.Conv2d:
+    """3x3 convolution with padding"""
+    return nn.Conv2d(
+        in_planes,
+        out_planes,
+        kernel_size=3,
+        stride=stride,
+        padding=dilation,
+        groups=groups,
+        bias=False,
+        dilation=dilation,
+    )
+
+
+def conv1x1(in_planes: int, out_planes: int, stride: int = 1) -> nn.Conv2d:
+    """1x1 convolution"""
+    return nn.Conv2d(in_planes, out_planes, kernel_size=1, stride=stride, bias=False)
+
+
+class BasicBlock(nn.Module):
+    expansion: int = 1
+
+    def __init__(
+        self,
+        inplanes: int,
+        planes: int,
+        stride: int = 1,
+        downsample: Optional[nn.Module] = None,
+        groups: int = 1,
+        base_width: int = 64,
+        dilation: int = 1,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+    ) -> None:
+        super(BasicBlock, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        if groups != 1 or base_width != 64:
+            raise ValueError("BasicBlock only supports groups=1 and base_width=64")
+        if dilation > 1:
+            raise NotImplementedError("Dilation > 1 not supported in BasicBlock")
+        # Both self.conv1 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv3x3(inplanes, planes, stride)
+        self.bn1 = norm_layer(planes)
+        self.relu = nn.ReLU(inplace=True)
+        self.conv2 = conv3x3(planes, planes)
+        self.bn2 = norm_layer(planes)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x: Tensor) -> Tensor:
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class Bottleneck(nn.Module):
+    # Bottleneck in oneflow places the stride for downsampling at 3x3 convolution(self.conv2)
+    # while original implementation places the stride at the first 1x1 convolution(self.conv1)
+    # according to "Deep residual learning for image recognition"https://arxiv.org/abs/1512.03385.
+    # This variant is also known as ResNet V1.5 and improves accuracy according to
+    # https://ngc.nvidia.com/catalog/model-scripts/nvidia:resnet_50_v1_5_for_pytorch.
+
+    expansion: int = 4
+
+    def __init__(
+        self,
+        inplanes: int,
+        planes: int,
+        stride: int = 1,
+        downsample: Optional[nn.Module] = None,
+        groups: int = 1,
+        base_width: int = 64,
+        dilation: int = 1,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+    ) -> None:
+        super(Bottleneck, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        width = int(planes * (base_width / 64.0)) * groups
+        # Both self.conv2 and self.downsample layers downsample the input when stride != 1
+        self.conv1 = conv1x1(inplanes, width)
+        self.bn1 = norm_layer(width)
+        self.conv2 = conv3x3(width, width, stride, groups, dilation)
+        self.bn2 = norm_layer(width)
+        self.conv3 = conv1x1(width, planes * self.expansion)
+        self.bn3 = norm_layer(planes * self.expansion)
+        self.relu = nn.ReLU(inplace=True)
+        self.downsample = downsample
+        self.stride = stride
+
+    def forward(self, x: Tensor) -> Tensor:
+        identity = x
+
+        out = self.conv1(x)
+        out = self.bn1(out)
+        out = self.relu(out)
+
+        out = self.conv2(out)
+        out = self.bn2(out)
+        out = self.relu(out)
+
+        out = self.conv3(out)
+        out = self.bn3(out)
+
+        if self.downsample is not None:
+            identity = self.downsample(x)
+
+        out += identity
+        out = self.relu(out)
+
+        return out
+
+
+class ResNet(nn.Module):
+    def __init__(
+        self,
+        block: Type[Union[BasicBlock, Bottleneck]],
+        layers: List[int],
+        num_classes: int = 1000,
+        zero_init_residual: bool = False,
+        groups: int = 1,
+        width_per_group: int = 64,
+        replace_stride_with_dilation: Optional[List[bool]] = None,
+        norm_layer: Optional[Callable[..., nn.Module]] = None,
+    ) -> None:
+        super(ResNet, self).__init__()
+        if norm_layer is None:
+            norm_layer = nn.BatchNorm2d
+        self._norm_layer = norm_layer
+
+        self.inplanes = 64
+        self.dilation = 1
+        if replace_stride_with_dilation is None:
+            # each element in the tuple indicates if we should replace
+            # the 2x2 stride with a dilated convolution instead
+            replace_stride_with_dilation = [False, False, False]
+        if len(replace_stride_with_dilation) != 3:
+            raise ValueError(
+                "replace_stride_with_dilation should be None "
+                "or a 3-element tuple, got {}".format(replace_stride_with_dilation)
+            )
+        self.groups = groups
+        self.base_width = width_per_group
+        self.conv1 = nn.Conv2d(
+            3, self.inplanes, kernel_size=7, stride=2, padding=3, bias=False
+        )
+        self.bn1 = norm_layer(self.inplanes)
+        self.relu = nn.ReLU(inplace=True)
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        self.layer1 = self._make_layer(block, 64, layers[0])
+        self.layer2 = self._make_layer(
+            block, 128, layers[1], stride=2, dilate=replace_stride_with_dilation[0]
+        )
+        self.layer3 = self._make_layer(
+            block, 256, layers[2], stride=2, dilate=replace_stride_with_dilation[1]
+        )
+        self.layer4 = self._make_layer(
+            block, 512, layers[3], stride=2, dilate=replace_stride_with_dilation[2]
+        )
+        self.avgpool = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(512 * block.expansion, num_classes)
+
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out", nonlinearity="relu")
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.constant_(m.weight, 1)
+                nn.init.constant_(m.bias, 0)
+
+        # Zero-initialize the last BN in each residual branch,
+        # so that the residual branch starts with zeros, and each residual block behaves like an identity.
+        # This improves the model by 0.2~0.3% according to https://arxiv.org/abs/1706.02677
+        if zero_init_residual:
+            for m in self.modules():
+                if isinstance(m, Bottleneck):
+                    # type: ignore[arg-type]
+                    nn.init.constant_(m.bn3.weight, 0)
+                elif isinstance(m, BasicBlock):
+                    # type: ignore[arg-type]
+                    nn.init.constant_(m.bn2.weight, 0)
+
+    def _make_layer(
+        self,
+        block: Type[Union[BasicBlock, Bottleneck]],
+        planes: int,
+        blocks: int,
+        stride: int = 1,
+        dilate: bool = False,
+    ) -> nn.Sequential:
+        norm_layer = self._norm_layer
+        downsample = None
+        previous_dilation = self.dilation
+        if dilate:
+            self.dilation *= stride
+            stride = 1
+        if stride != 1 or self.inplanes != planes * block.expansion:
+            downsample = nn.Sequential(
+                conv1x1(self.inplanes, planes * block.expansion, stride),
+                norm_layer(planes * block.expansion),
+            )
+
+        layers = []
+        layers.append(
+            block(
+                self.inplanes,
+                planes,
+                stride,
+                downsample,
+                self.groups,
+                self.base_width,
+                previous_dilation,
+                norm_layer,
+            )
+        )
+        self.inplanes = planes * block.expansion
+        for _ in range(1, blocks):
+            layers.append(
+                block(
+                    self.inplanes,
+                    planes,
+                    groups=self.groups,
+                    base_width=self.base_width,
+                    dilation=self.dilation,
+                    norm_layer=norm_layer,
+                )
+            )
+
+        return nn.Sequential(*layers)
+
+    def _forward_impl(self, x: Tensor) -> Tensor:
+        x = self.conv1(x)
+        x = self.bn1(x)
+        x = self.relu(x)
+        x = self.maxpool(x)
+
+        x = self.layer1(x)
+        x = self.layer2(x)
+        x = self.layer3(x)
+        x = self.layer4(x)
+
+        x = self.avgpool(x)
+        x = flow.flatten(x, 1)
+        x = self.fc(x)
+
+        return x
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self._forward_impl(x)
+
+
+def _resnet(
+    arch: str,
+    block: Type[Union[BasicBlock, Bottleneck]],
+    layers: List[int],
+    pretrained: bool,
+    progress: bool,
+    **kwargs: Any
+) -> ResNet:
+    model = ResNet(block, layers, **kwargs)
+    if pretrained:
+        state_dict = load_state_dict_from_url(model_urls[arch], progress=progress)
+        model.load_state_dict(state_dict)
+    return model
+
+
+def wide_resnet50_2(pretrained=False, progress=True, **kwargs):
+    r"""Wide ResNet-50-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet50_2', Bottleneck, [3, 4, 6, 3],
+                   pretrained, progress, **kwargs)
+
+def wide_resnet101_2(pretrained=False, progress=True, **kwargs):
+    r"""Wide ResNet-101-2 model from
+    `"Wide Residual Networks" <https://arxiv.org/pdf/1605.07146.pdf>`_
+
+    The model is the same as ResNet except for the bottleneck number of channels
+    which is twice larger in every block. The number of channels in outer 1x1
+    convolutions is the same, e.g. last block in ResNet-50 has 2048-512-2048
+    channels, and in Wide ResNet-50-2 has 2048-1024-2048.
+
+    Args:
+        pretrained (bool): If True, returns a model pre-trained on ImageNet
+        progress (bool): If True, displays a progress bar of the download to stderr
+    """
+    kwargs['width_per_group'] = 64 * 2
+    return _resnet('wide_resnet101_2', Bottleneck, [3, 4, 23, 3],
+                   pretrained, progress, **kwargs)


### PR DESCRIPTION
本次PR提交的内容如下：
- 新增`wide_resnet50_2`, 以及`wide_resnet101_2`模型
- 验证torchvision版本在imagenet上的精度，并转换为OneFlow的权重
- `Wide ResNet`, `ResNet`, `ResNext`都可以整合到一个Repo里，只是超参不同，可以后续我来重新整合，然后完全对齐torchvision，放上pretrained weight的下载链接

验证结果：
以下验证结果是在输入和权重完全一致的情况下校验是否对齐
| model | version| dataset | acc@1 | acc@5 |
|:-------:|:--------:|:---------:|:-------:|:-------:|
| wide_resnet50_2 | Pytorch | ImageNet2012 | 77.2493 | 93.4901 |
| wide_resnet50_2 | OneFlow | ImageNet2012 | 77.2493 | 93.4901 |
| wide_resnet101_2 | Pytorch | ImageNet2012 | 77.9031 | 93.7480 |
| wide_resnet101_2 | OneFlow | ImageNet2012 | 77.9031 | 93.7480 |

Future Work:
- Eager版本训练
- Graph版本训练
- Check Model代码