### PR TITLE
nn_graph_wide_and_deep_multi_gpus

### DIFF
--- a/wide_and_deep/eager_train_ddp.py
+++ b/wide_and_deep/eager_train_ddp.py
@@ -1,0 +1,104 @@
+import os
+import time
+import numpy as np
+from sklearn.metrics import roc_auc_score
+import oneflow as flow
+from tqdm import tqdm
+from config import get_args
+from dataloader_utils import OFRecordDataLoader
+from oneflow.framework import distribute
+from wide_and_deep_module import WideAndDeep
+from util import dump_to_npy, save_param_npy
+from oneflow.nn.parallel import DistributedDataParallel as ddp
+
+
+def prepare_modules(args):
+    train_dataloader = OFRecordDataLoader(
+        args, data_root=args.data_dir, batch_size=args.batch_size)
+    val_dataloader = OFRecordDataLoader(
+        args, data_root=args.data_dir, mode="val",batch_size=args.batch_size)
+    wdl_module = WideAndDeep(args)
+    if args.model_load_dir != "":
+        print("load checkpointed model from ", args.model_load_dir)
+        wdl_module.load_state_dict(flow.load(args.model_load_dir))
+
+    if args.save_initial_model and args.model_save_dir != "":
+        path = os.path.join(args.model_save_dir, 'initial_checkpoint')
+        if not os.path.isdir(path):
+            flow.save(wdl_module.state_dict(), path)
+
+    bce_loss = flow.nn.BCELoss(reduction="mean")
+
+    wdl_module.to("cuda")
+    wdl_module=ddp(wdl_module)
+    bce_loss.to("cuda")
+
+    opt = flow.optim.SGD(
+        wdl_module.parameters(), lr=args.learning_rate, momentum=0.9
+    )
+    return train_dataloader, val_dataloader, wdl_module, bce_loss, opt
+
+
+def print_eval_metrics(step, loss, lables_list, predicts_list):
+    all_labels = np.concatenate(lables_list, axis=0)
+    all_predicts = np.concatenate(predicts_list, axis=0)
+    auc = "NaN" if np.isnan(all_predicts).any(
+    ) else roc_auc_score(all_labels, all_predicts)
+    print(f"iter {step} eval_loss {loss} auc {auc}")
+
+
+if __name__ == '__main__':
+    args = get_args()
+    world_size=flow.env.get_world_size()
+    batch_size=args.batch_size
+    distribute_num=int(batch_size/world_size)
+    train_dataloader, val_dataloader, wdl_module, loss, opt = prepare_modules(
+        args)
+
+    losses = []
+    wdl_module.train()
+    for i in tqdm(range(args.max_iter)):
+        rank_train = flow.env.get_rank()
+        labels, dense_fields, wide_sparse_fields, deep_sparse_fields = train_dataloader()
+
+        
+        labels = labels[rank_train*distribute_num:(rank_train+1)*distribute_num].to("cuda").to(dtype=flow.float32)
+        dense_fields = dense_fields[rank_train*distribute_num:(rank_train+1)*distribute_num].to("cuda")
+        wide_sparse_fields = wide_sparse_fields[rank_train*distribute_num:(rank_train+1)*distribute_num].to("cuda")
+        deep_sparse_fields = deep_sparse_fields[rank_train*distribute_num:(rank_train+1)*distribute_num].to("cuda")
+        predicts = wdl_module(
+            dense_fields, wide_sparse_fields, deep_sparse_fields)
+        train_loss = loss(predicts, labels)
+        losses.append(train_loss.numpy().mean())
+        train_loss.backward()
+        opt.step()
+        opt.zero_grad()
+        if (i+1) % args.print_interval == 0:
+            l = sum(losses) / len(losses)
+            losses = []
+            print(f"iter {i+1} train_loss {l} time {time.time()}")
+            if args.eval_batchs <= 0:
+                continue
+
+            eval_loss_acc = 0.0
+            lables_list = []
+            predicts_list = []
+            wdl_module.eval()
+            for j in range(args.eval_batchs):
+                rank_valid = flow.env.get_rank()
+                labels, dense_fields, wide_sparse_fields, deep_sparse_fields = val_dataloader()
+                labels = labels[rank_valid*distribute_num:(rank_valid+1)*distribute_num].to("cuda").to(dtype=flow.float32)
+                dense_fields = dense_fields[rank_valid*distribute_num:(rank_valid+1)*distribute_num].to("cuda")
+                wide_sparse_fields = wide_sparse_fields[rank_valid*distribute_num:(rank_valid+1)*distribute_num].to("cuda")
+                deep_sparse_fields = deep_sparse_fields[rank_valid*distribute_num:(rank_valid+1)*distribute_num].to("cuda")
+                predicts = wdl_module(
+                    dense_fields, wide_sparse_fields, deep_sparse_fields)
+                eval_loss = loss(predicts, labels)
+
+                eval_loss_acc += eval_loss.numpy().mean()
+                lables_list.append(labels.numpy())
+                predicts_list.append(predicts.numpy())
+
+            print_eval_metrics(i+1, eval_loss_acc/args.eval_batchs,
+                               lables_list, predicts_list)
+            wdl_module.train()

--- a/wide_and_deep/eager_train_ddp.sh
+++ b/wide_and_deep/eager_train_ddp.sh
@@ -1,0 +1,17 @@
+DEVICE_NUM_PER_NODE=2
+MASTER_ADDR=127.0.0.1
+NUM_NODES=1
+NODE_RANK=0
+
+# export CUDA_VISIBLE_DEVICES=3
+python3 -m oneflow.distributed.launch \
+    --nproc_per_node $DEVICE_NUM_PER_NODE \
+    --nnodes $NUM_NODES \
+    --node_rank $NODE_RANK \
+    --master_addr $MASTER_ADDR \
+    eager_train_ddp.py \
+        --model_save_dir ./checkpoints \
+        --print_interval 100 \
+        --deep_dropout_rate 0 \
+        --max_iter 1000
+


### PR DESCRIPTION
本PR要解决的：
- [ ] 多卡模式下，数据并行，eager训练验证脚本。
- [ ] 多卡模式下，数据并行，graph训练验证脚本。
- [ ] 多卡模式下，模型并行embedding split(0)，eager训练验证脚本。
- [ ] 多卡模式下，模型并行embedding split(0)，graph训练验证脚本。
- [ ] 多卡模式下，模型并行embedding split(1)，eager训练验证脚本。
- [ ] 多卡模式下，模型并行embedding split(1)，graph训练验证脚本。
- [ ] 以上与以前的wide&deep对齐。
- [ ] 以上与原来的wide&deep进行对比测试，变量有batch_size, vocab_size, AUC, latency, number of GPU等。
- [ ] 完成上述工作后，与HugeCTR对对齐。
- [ ] 完成上述工作后，以上与HugeCTR进行对比测试。

后续整理
- [ ] 脚本整理
- [ ] 文档
