### PR TITLE
Refine resnet logger

### DIFF
--- a/resnet50/utils/logger.py
+++ b/resnet50/utils/logger.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 import numpy as np
 import oneflow as flow
 
@@ -58,7 +59,7 @@ class Logger(object):
 
         do_print = self.rank in (print_ranks or self.print_ranks)
         if do_print:
-            print("[{}] {}".format(self.rank, ", ".join(fields)))
+            print("[rank:{}] {}".format(self.rank, ", ".join(fields)), datetime.utcnow().strftime('| %Y-%m-%d %H:%M:%S.%f')[:-3])
 
     def print(self, *args, print_ranks=None):
         do_print = self.rank in (print_ranks or self.print_ranks)

--- a/resnet50/utils/logger.py
+++ b/resnet50/utils/logger.py
@@ -59,7 +59,7 @@ class Logger(object):
 
         do_print = self.rank in (print_ranks or self.print_ranks)
         if do_print:
-            print("[rank:{}] {}".format(self.rank, ", ".join(fields)), datetime.utcnow().strftime('| %Y-%m-%d %H:%M:%S.%f')[:-3])
+            print("[rank:{}] {}".format(self.rank, ", ".join(fields)), datetime.now().strftime('| %Y-%m-%d %H:%M:%S.%f')[:-3])
 
     def print(self, *args, print_ranks=None):
         do_print = self.rank in (print_ranks or self.print_ranks)


### PR DESCRIPTION
**refine resnet50 logger，add timestamp**

### befor
```shell
[1] [train], epoch: 0/50, iter: 100/3336, loss: 1.73143, lr: 0.004604, top1: 0.00167, throughput: 161.66
[0] [train], epoch: 0/50, iter: 100/3336, loss: 1.73064, lr: 0.004604, top1: 0.00208, throughput: 159.71
[3] [train], epoch: 0/50, iter: 100/3336, loss: 1.73078, lr: 0.004604, top1: 0.00167, throughput: 159.48
[2] [train], epoch: 0/50, iter: 100/3336, loss: 1.73150, lr: 0.004604, top1: 0.00146, throughput: 159.49
```

### afer
![Snip20210910_4](https://user-images.githubusercontent.com/28823622/132838604-8b252d32-a1f2-4b09-89f0-b89fe8198bd2.png)

