### PR TITLE
[Don't merge] Add debug changes for ddp

### DIFF
--- a/resnet50/examples/train_ddp.sh
+++ b/resnet50/examples/train_ddp.sh
@@ -1,6 +1,6 @@
 # set -aux
 
-DEVICE_NUM_PER_NODE=8
+DEVICE_NUM_PER_NODE=2
 MASTER_ADDR=127.0.0.1
 NUM_NODES=1
 NODE_RANK=0
@@ -12,7 +12,7 @@ echo NCCL_LAUNCH_MODE=$NCCL_LAUNCH_MODE
 # export NCCL_DEBUG=INFO
 # export ONEFLOW_DEBUG_MODE=True
 
-CHECKPOINT_SAVE_PATH="./ddp_checkpoints"
+CHECKPOINT_SAVE_PATH="./ddp_checkpoints_simple3"
 if [ ! -d "$CHECKPOINT_SAVE_PATH" ]; then
     mkdir $CHECKPOINT_SAVE_PATH
 fi
@@ -26,11 +26,11 @@ fi
 
 OFRECORD_PATH=/dataset/ImageNet/ofrecord/
 OFRECORD_PART_NUM=256
-LEARNING_RATE=0.768
+LEARNING_RATE=0.128
 MOM=0.875
 EPOCH=50
-TRAIN_BATCH_SIZE=96
-VAL_BATCH_SIZE=50
+TRAIN_BATCH_SIZE=16
+VAL_BATCH_SIZE=1
 
 # SRC_DIR=/path/to/models/resnet50
 SRC_DIR=$(realpath $(dirname $0)/..)
@@ -40,14 +40,19 @@ python3 -m oneflow.distributed.launch \
     --nnodes $NUM_NODES \
     --node_rank $NODE_RANK \
     --master_addr $MASTER_ADDR \
+    --logdir logdist \
     $SRC_DIR/train.py \
         --save $CHECKPOINT_SAVE_PATH \
+        --load $CHECKPOINT_LOAD_PATH \
+        --warmup-epochs 0 \
+        --print-interval 1  \
         --ofrecord-path $OFRECORD_PATH \
         --ofrecord-part-num $OFRECORD_PART_NUM \
         --num-devices-per-node $DEVICE_NUM_PER_NODE \
         --lr $LEARNING_RATE \
         --momentum $MOM \
         --num-epochs $EPOCH \
+        --total-batches 200 \
         --train-batch-size $TRAIN_BATCH_SIZE \
         --val-batch-size $VAL_BATCH_SIZE \
         --ddp \

--- a/resnet50/models/data.py
+++ b/resnet50/models/data.py
@@ -1,3 +1,4 @@
+import numpy as np
 import os
 import oneflow as flow
 
@@ -138,6 +139,9 @@ class OFRecordDataLoader(flow.nn.Module):
         return self.dataset_size // self.total_batch_size
 
     def forward(self):
+        image = flow.tensor(np.arange(self.batch_size * 3 * 224 * 224).reshape((self.batch_size, 3, 224, 224)).astype(np.float32))
+        label = flow.tensor(np.arange(self.batch_size).astype(np.int32))
+        return image, label
         if self.mode == "train":
             record = self.ofrecord_reader()
             if self.use_gpu_decode:

--- a/resnet50/models/resnet50.py
+++ b/resnet50/models/resnet50.py
@@ -254,6 +254,7 @@ class ResNet(nn.Module):
         x = self.avgpool(x)
         x = flow.flatten(x, 1)
         x = self.fc(x)
+        print(f'fc: {x.sum()}')
 
         return x
 


### PR DESCRIPTION
**需和 oneflow 仓库的 ddp_debug 分支一起使用**

这个分支使用固定的输入数据运行 ddp 训练，会观察到数个 iteration 之后两个 rank 的输出变得不一样。如：

```
[0] [train], epoch: 0/50, iter: 8/40036, loss: 2.12962, lr: 0.128000, top1: 0.25000, throughput: 19.68
[1] [train], epoch: 0/50, iter: 8/40036, loss: 2.12962, lr: 0.128000, top1: 0.25000, throughput: 18.48
fc: -296.9427490234375
fc: -296.9427490234375
[0] [train], epoch: 0/50, iter: 9/40036, loss: 2.88117, lr: 0.128000, top1: 0.06250, throughput: 17.92
[1] [train], epoch: 0/50, iter: 9/40036, loss: 2.88117, lr: 0.128000, top1: 0.06250, throughput: 19.10
fc: -194.5577392578125
fc: -194.559326171875
[1] [train], epoch: 0/50, iter: 10/40036, loss: 2.75178, lr: 0.128000, top1: 0.06250, throughput: 20.53
[0] [train], epoch: 0/50, iter: 10/40036, loss: 2.75182, lr: 0.128000, top1: 0.06250, throughput: 20.24
fc: -166.83737182617188
fc: -166.83641052246094
```