### PR TITLE
rename flow.F to flow._C

### DIFF
--- a/NLP/CPT/README.md
+++ b/NLP/CPT/README.md
@@ -10,9 +10,9 @@ CPT supports both understanding and generation task. CPT has two kinds of decode
 - `cls_mode = 2`: Only decoder, or DG only.
 - `cls_mode = 3`: Both encoder and decoder.
 
-Since oneflow does not have some operators, we implemented some extra functions:
+We implemented some extra functions here:
 
-- `LayerNorm` in `models/dev_ops.py`
+<!-- - `LayerNorm` in `models/dev_ops.py` -->
 - `tensor_unique` in `models/bart_utils.py`
 - `position_scores` in `models/bert_utils.py`
 

--- a/NLP/CPT/README.md
+++ b/NLP/CPT/README.md
@@ -24,7 +24,7 @@ After training, CPT can figure out if the two input sentences are of the same me
 
 First, get the dataset:
 ```bash
-wget https://oneflow-public.oss-cn-beijing.aliyuncs.com/model_zoo/nlp/CPT/clu_afqmc.tar.gz
+wget https://oneflow-public.oss-cn-beijing.aliyuncs.com/model_zoo/nlp/CPT/clue_afqmc.tar.gz
 tar -xzf clue_afqmc.tar.gz
 ```
 

--- a/NLP/CPT/models/CPT.py
+++ b/NLP/CPT/models/CPT.py
@@ -20,10 +20,10 @@ from .bart_utils import (
 from .dev_ops import LayerNorm
 
 ACT2FN = {
-    "relu": flow.F.relu,
+    "relu": flow._C.relu,
     # "silu": silu,
     # "swish": silu,
-    "gelu": flow.F.gelu,
+    "gelu": flow._C.gelu,
     "tanh": flow.tanh,
     # "gelu_new": gelu_new,
     # "gelu_fast": gelu_fast,
@@ -192,7 +192,7 @@ class BartAttention(nn.Module):
         # attn_probs = flow.F.dropout(attn_weights, p=prob)
         # attn_output = flow.bmm(attn_probs, value_states)
         if self.training:
-            attn_weights = flow.F.dropout(attn_weights, p=self.dropout)
+            attn_weights = flow._C.dropout(attn_weights, p=self.dropout)
         attn_output = flow.bmm(attn_weights, value_states)
 
         assert attn_output.size() == (
@@ -274,7 +274,7 @@ class BartDecoderLayer(nn.Module):
             output_attentions,
         )
         if self.training:
-            hidden_states = flow.F.dropout(hidden_states, p=self.dropout)
+            hidden_states = flow._C.dropout(hidden_states, p=self.dropout)
         hidden_states = residual + hidden_states
         hidden_states = self.self_attn_layer_norm(hidden_states)
 
@@ -301,7 +301,7 @@ class BartDecoderLayer(nn.Module):
                 output_attentions,
             )
             if self.training:
-                hidden_states = flow.F.dropout(hidden_states, p=self.dropout)
+                hidden_states = flow._C.dropout(hidden_states, p=self.dropout)
             hidden_states = residual + hidden_states
             hidden_states = self.encoder_attn_layer_norm(hidden_states)
 
@@ -312,10 +312,10 @@ class BartDecoderLayer(nn.Module):
         residual = hidden_states
         hidden_states = self.activation_fn(self.fc1(hidden_states))
         if self.training:
-            hidden_states = flow.F.dropout(hidden_states, p=self.activation_dropout)
+            hidden_states = flow._C.dropout(hidden_states, p=self.activation_dropout)
         hidden_states = self.fc2(hidden_states)
         if self.training:
-            hidden_states = flow.F.dropout(hidden_states, p=self.dropout)
+            hidden_states = flow._C.dropout(hidden_states, p=self.dropout)
         hidden_states = residual + hidden_states
         hidden_states = self.final_layer_norm(hidden_states)
 
@@ -475,7 +475,7 @@ class BartDecoder(nn.Module):
         hidden_states = self.layernorm_embedding(hidden_states)
 
         if self.training:
-            hidden_states = flow.F.dropout(hidden_states, p=self.dropout)
+            hidden_states = flow._C.dropout(hidden_states, p=self.dropout)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/NLP/CPT/models/bert.py
+++ b/NLP/CPT/models/bert.py
@@ -16,10 +16,10 @@ from .bert_utils import (
 )
 
 ACT2FN = {
-    "relu": flow.F.relu,
+    "relu": flow._C.relu,
     # "silu": silu,
     # "swish": silu,
-    "gelu": flow.F.gelu,
+    "gelu": flow._C.gelu,
     "tanh": flow.tanh,
     # "gelu_new": gelu_new,
     # "gelu_fast": gelu_fast,

--- a/NLP/Transformer/odd_numbers/train_transformer_odd_numbers.py
+++ b/NLP/Transformer/odd_numbers/train_transformer_odd_numbers.py
@@ -119,12 +119,12 @@ def test(model, max_len=3, test_times=1, display=False):
         for i in range(test_times):
             s = np.random.randint(1, 4998)
             cpu_src = [(s + j) * 2 for j in range(max_len)]
-            src = to_cuda(flow.Tensor(cpu_src, dtype=flow.int64).unsqueeze(1))
+            src = to_cuda(flow.tensor(cpu_src, dtype=flow.int64).unsqueeze(1))
             tgt = [0] + [(s + j) * 2 + 1 for j in range(max_len)]
             pred = [0]
             flag = 1
             for j in range(max_len):
-                inp = to_cuda(flow.Tensor(pred, dtype=flow.int64).unsqueeze(1))
+                inp = to_cuda(flow.tensor(pred, dtype=flow.int64).unsqueeze(1))
                 output = model(src, inp)
                 out_num = output.argmax(2)[-1].numpy()[0]
                 pred.append(out_num)

--- a/NLP/Transformer/transformer/utils.py
+++ b/NLP/Transformer/transformer/utils.py
@@ -22,7 +22,7 @@ def pad(input, padding, mode="constant"):
     for i in range(4 - origin_dim):
         input = input.unsqueeze(0)
 
-    input = flow.F.pad(input, padding, mode=mode)
+    input = flow._C.pad(input, padding, mode=mode)
 
     for i in range(4 - origin_dim):
         input = input.squeeze(0)

--- a/ops/nms.py
+++ b/ops/nms.py
@@ -5,7 +5,7 @@ from oneflow import Tensor
 
 def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:
     scores_inds = flow_exp.argsort(scores, dim=0, descending=True)
-    boxes = flow.F.gather(boxes, scores_inds, axis=0)
+    boxes = flow._C.gather(boxes, scores_inds, axis=0)
     _nms_op = (
         flow_exp.builtin_op("nms")
         .Input("in")
@@ -16,4 +16,4 @@ def nms(boxes: Tensor, scores: Tensor, iou_threshold: float) -> Tensor:
     )
     keep = _nms_op(boxes)[0]
     index = flow_exp.squeeze(flow_exp.argwhere(keep), dim=[1])
-    return flow.F.gather(scores_inds, index, axis=0)
+    return flow._C.gather(scores_inds, index, axis=0)


### PR DESCRIPTION
本次PR的目的是将原models仓库下的`flow.F`改为`flow._C`
- [x] 代码修改
- [x] 验证模型正确性（参考模型 NLP/CPT）

修改后跑了Transformer发现了另外一个问题，相关代码如下
```python
flow.Tensor(cpu_src, dtype=flow.int64)
```
报错如下
```
Traceback (most recent call last):
  File "train_transformer_odd_numbers.py", line 193, in <module>
    main()
  File "train_transformer_odd_numbers.py", line 188, in main
    print(test(model, test_times=10))
  File "train_transformer_odd_numbers.py", line 122, in test
    src = to_cuda(flow.Tensor(cpu_src, dtype=flow.int64).unsqueeze(1))
oneflow._oneflow_internal.exception.TypeException: 
  File "/home/rentianhe/oneflow_env/oneflow/oneflow/api/python/functional/py_function.h", line 69, in call
    TypeError: _legacy_tensor_ctor(): received an invalid combination of arguments. The valid signatures are:
        *0: Tensor (*, Device device=None)
        *1: Tensor (*, Placement placement, SbpList sbp)
        *2: Tensor (Tensor other)
        *3: Tensor (PyObject* data, *, Device device=None)
        *4: Tensor (PyObject* data, *, Placement placement, SbpList sbp)
        *5: Tensor (Shape size, *, Device device=None)
```
改为以下形式后不会报相关错误：
```python
flow.tensor(cpu_src, dtype=flow.int64)
```