### PR TITLE
Update train.sh

### DIFF
--- a/Vision/style_transform/fast_neural_style/train.sh
+++ b/Vision/style_transform/fast_neural_style/train.sh
@@ -1,6 +1,11 @@
 PRETRAIN_MODEL_PATH="vgg_imagenet_pretrain_model/"
 MODEL="vgg16" # choose from vgg16 and vgg19
 
+if [ ! -d "images" ]; then
+  wget https://oneflow-public.oss-cn-beijing.aliyuncs.com/model_zoo/cv/fast_neural_style/images.tar.gz
+  tar zxf images.tar.gz
+fi
+
 if [ ! -d "$PRETRAIN_MODEL_PATH" ]; then
   mkdir ${PRETRAIN_MODEL_PATH}
 fi


### PR DESCRIPTION
直接执行train.sh时由于没有images文件导致报错

Traceback (most recent call last):
File "neural_style/neural_style.py", line 333, in
main()
File "neural_style/neural_style.py", line 327, in main
train(args)
File "neural_style/neural_style.py", line 72, in train
image = load_image("%s/%s" % (args.dataset, train_images[i]))
File "/workspace/neural_style/utils.py", line 28, in load_image
im = cv2.cvtColor(im, cv2.COLOR_BGR2RGB)
cv2.error: OpenCV(4.5.3) /tmp/pip-req-build-l1r0y34w/opencv/modules/imgproc/src/color.cpp:182: error: (-215:Assertion failed) !_src.empty() in function 'cvtColor'