### PR TITLE
default ckpt path is None

### DIFF
--- a/Vision/classification/image/resnet50/config.py
+++ b/Vision/classification/image/resnet50/config.py
@@ -29,7 +29,7 @@ def parse_args(ignore_unknown_args=False):
     parser.add_argument(
         "--save",
         type=str,
-        default="./checkpoints",
+        default=None,
         dest="save_path",
         help="root dir of saving checkpoint",
     )


### PR DESCRIPTION
Set default checkpoint path to None(python null value, but not string `None`). 
otherwise following condition in [resnet50 train.py](https://github.com/Oneflow-Inc/models/blob/main/Vision/classification/image/resnet50/train.py#L332) will never be met
```python
    def save(self, subdir):
        if self.save_path is None:
            return
```
