### PR TITLE
refine_consistent_wide_and_deep_module

### DIFF
--- a/RecommenderSystems/wide_and_deep/train.py
+++ b/RecommenderSystems/wide_and_deep/train.py
@@ -46,7 +46,7 @@ class Trainer(object):
         self.init_logger()
         self.train_dataloader = make_data_loader(args, "train", self.is_consistent, self.dataset_format)
         self.val_dataloader = make_data_loader(args, "val", self.is_consistent, self.dataset_format)
-        self.wdl_module = make_wide_and_deep_module(args, self.is_consistent, self.execution_mode == "graph")
+        self.wdl_module = make_wide_and_deep_module(args, self.is_consistent)
         self.init_model()
         self.opt = flow.optim.Adam(
             self.wdl_module.parameters(), lr=args.learning_rate


### PR DESCRIPTION
此前由于opkernel state 缓存问题，导致ConsistentWideAndDeep module在eager consistent 和 nnGraph下有所不同，目前opkernel state 缓存问题已经解决，本pr修改ConsistentWideAndDeep，统一 eager consistent 和 nnGraph。