### PR TITLE
Dlrm key type

### DIFF
--- a/RecommenderSystems/dlrm/dlrm_train_eval.py
+++ b/RecommenderSystems/dlrm/dlrm_train_eval.py
@@ -41,6 +41,7 @@ def get_args(print_args=True):
 
     parser.add_argument("--disable_fusedmlp", action="store_true", help="disable fused MLP or not")
     parser.add_argument("--embedding_vec_size", type=int, default=128)
+    parser.add_argument("--one_embedding_key_type", type=str, default="int64", help="OneEmbedding key type: int32, int64")
     parser.add_argument("--bottom_mlp", type=int_list, default="512,256,128")
     parser.add_argument("--top_mlp", type=int_list, default="1024,1024,512,256")
     parser.add_argument(
@@ -266,6 +267,7 @@ class OneEmbedding(nn.Module):
         table_size_array,
         store_type,
         cache_memory_budget_mb,
+        key_type,
     ):
         assert table_size_array is not None
         vocab_size = sum(table_size_array)
@@ -303,7 +305,7 @@ class OneEmbedding(nn.Module):
             "sparse_embedding",
             embedding_dim=embedding_vec_size,
             dtype=flow.float,
-            key_type=flow.int64,
+            key_type=getattr(flow, key_type),
             tables=tables,
             store_options=store_options,
         )
@@ -322,6 +324,7 @@ class DLRMModule(nn.Module):
         persistent_path=None,
         table_size_array=None,
         one_embedding_store_type="cached_host_mem",
+        one_embedding_key_type="int64",
         cache_memory_budget_mb=8192,
         interaction_itself=True,
         interaction_padding=True,
@@ -337,6 +340,7 @@ class DLRMModule(nn.Module):
             table_size_array,
             one_embedding_store_type,
             cache_memory_budget_mb,
+            one_embedding_key_type,
         )
         self.interaction = Interaction(
             bottom_mlp[-1],
@@ -368,6 +372,7 @@ def make_dlrm_module(args):
         persistent_path=args.persistent_path,
         table_size_array=args.table_size_array,
         one_embedding_store_type=args.store_type,
+        one_embedding_key_type=args.one_embedding_key_type,
         cache_memory_budget_mb=args.cache_memory_budget_mb,
         interaction_itself=args.interaction_itself,
         interaction_padding=not args.disable_interaction_padding,


### PR DESCRIPTION
- support config oneembedding key_type, `int32` or `int64`
- support dense input padding