### PR TITLE
Tensor.view bugfix

### DIFF
--- a/Vision/classification/image/ViT/model/vit.py
+++ b/Vision/classification/image/ViT/model/vit.py
@@ -109,7 +109,7 @@ class SelfAttention(nn.Module):
         out = flow.matmul(attn_weights, v)
         out = out.permute(0, 2, 1, 3)
         new_out_shape = tuple(out.size()[:-2]) + (self.heads * self.head_dim,)
-        out = out.view(*new_out_shape)
+        out = out.reshape(*new_out_shape)
         out = self.out(out)
 
         return out

--- a/Vision/classification/image/swin_transformer/models/swin_transformer.py
+++ b/Vision/classification/image/swin_transformer/models/swin_transformer.py
@@ -42,7 +42,7 @@ class DropPath(nn.Module):
 def window_partition(x, window_size):
     B, H, W, C = x.shape
     x = x.view(B, H // window_size, window_size, W // window_size, window_size, C)
-    windows = x.permute(0, 1, 3, 2, 4, 5).view(-1, window_size, window_size, C)
+    windows = x.permute(0, 1, 3, 2, 4, 5).reshape(-1, window_size, window_size, C)
     return windows
 
 
@@ -51,7 +51,7 @@ def window_reverse(windows, window_size, H, W):
     x = windows.view(
         B, H // window_size, W // window_size, window_size, window_size, -1
     )
-    x = x.permute(0, 1, 3, 2, 4, 5).view(B, H, W, -1)
+    x = x.permute(0, 1, 3, 2, 4, 5).reshape(B, H, W, -1)
     return x
 
 


### PR DESCRIPTION
修复了tensor.view()的如下报错
```txt
RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.
```